### PR TITLE
Move the placeholder command line to typer (#33)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,4 +9,7 @@ Write the docstring; this page follows.
 
 ## The command line
 
-::: newpkg.cli.main
+The whole module, because typer makes every verb a plain function with a docstring, and
+`newpkg.cli:app` — the object `[project.scripts]` registers — is built from them.
+
+::: newpkg.cli

--- a/pixi.lock
+++ b/pixi.lock
@@ -53,12 +53,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vale-3.19.0-hee9eb32_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -67,19 +70,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.6.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -88,8 +97,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.6.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
@@ -168,6 +180,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zensical-0.0.57-py310haab479f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -178,7 +191,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-1.4.4-pyhd8ed1ab_0.conda
@@ -197,9 +212,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.15-h4df99d1_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
@@ -207,6 +225,7 @@ environments:
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
@@ -217,7 +236,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-autorefs-1.4.4-pyhd8ed1ab_0.conda
@@ -236,9 +257,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.15-h4df99d1_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
@@ -317,12 +341,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/vale-3.19.0-hee9eb32_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -331,19 +358,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.6.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: ./
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -352,8 +385,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-build-1.6.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
@@ -995,6 +1031,19 @@ packages:
   run_exports: {}
   size: 8144
   timestamp: 1784221492234
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+  sha256: a0a320c709fded9b5178108dedebf81a1f5a5d9c7720e3af50c1ab058dadd296
+  md5: d68ec17cb915cab4642357417ec0a104
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-doc?source=hash-mapping
+  run_exports: {}
+  size: 16785
+  timestamp: 1785335690199
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
   sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
   md5: 0f51e2391ade309db462a55611263e9c
@@ -1145,6 +1194,19 @@ packages:
   run_exports: {}
   size: 86721
   timestamp: 1785479173893
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+  sha256: 0c4c35376fe920714390d46e4b8d31c876d65f18e1655899e0763ec25f2a902f
+  md5: 6d03368f2b2b0a5fb6839df53b2eb5e0
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/markdown-it-py?source=hash-mapping
+  run_exports: {}
+  size: 69017
+  timestamp: 1778169663339
 - conda: https://conda.anaconda.org/conda-forge/noarch/markdownlint-cli2-0.23.2-h24b164e_0.conda
   sha256: 08d5b94d9ebc34b3ccf7155737acb9dc67be5ef6f1f6b987dbf3249333d701c9
   md5: d5393b1764b14e83a94fc4fc9174cf65
@@ -1156,6 +1218,18 @@ packages:
   run_exports: {}
   size: 2241022
   timestamp: 1785154531757
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mdurl?source=hash-mapping
+  run_exports: {}
+  size: 14465
+  timestamp: 1733255681319
 - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
   sha256: e5b555fd638334a253d83df14e3c913ef8ce10100090e17fd6fb8e752d36f95d
   md5: d9a8fc1f01deae61735c88ec242e855c
@@ -1456,6 +1530,22 @@ packages:
   run_exports: {}
   size: 11137
   timestamp: 1747237061448
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+  sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
+  md5: 0242025a3c804966bf71aa04eee82f66
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.10
+  - typing_extensions >=4.0.0,<5.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rich?source=hash-mapping
+  run_exports: {}
+  size: 208577
+  timestamp: 1775991661559
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
   sha256: 9e200ee5f9ff19a4d94e4b51c4856d53dec849f91032f345cf0c6bc3d51a7183
   md5: 62ac906f1cd582c6c264c95625cb9d6f
@@ -1468,6 +1558,18 @@ packages:
   run_exports: {}
   size: 524488
   timestamp: 1786282924579
+- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
+  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/shellingham?source=hash-mapping
+  run_exports: {}
+  size: 15018
+  timestamp: 1762858315311
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -1494,6 +1596,22 @@ packages:
   run_exports: {}
   size: 21561
   timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
+  sha256: 5809840f0ae1330d0cfa785f573ff53fd3725578a01997ca36c7f0e2da1ef4d0
+  md5: d076f2370a590b3698399256b9b135e3
+  depends:
+  - annotated-doc >=0.0.2
+  - colorama
+  - python >=3.10
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  - python
+  license: MIT AND BSD-3-Clause
+  purls:
+  - pkg:pypi/typer?source=compressed-mapping
+  run_exports: {}
+  size: 188056
+  timestamp: 1787921102267
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
   sha256: b141933ece3518f6d7b75dfb59451e2f26b405a44c18e2518a83e9a02e09315c
   md5: c680b5747e8c4c8f23dca0bb7042a8fc
@@ -2031,4 +2149,6 @@ packages:
   timestamp: 1786599629846
 - pypi: ./
   name: liulab-newpkg
+  requires_dist:
+  - typer>=0.12
   requires_python: '>=3.13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,13 @@ classifiers = [
 ]
 # hatch-vcs reads the newest git tag. Never add a `version` key here.
 dynamic = ["version"]
-dependencies = []
+# The command line's framework, and the only runtime dependency the placeholder has. A wheel
+# that registers a command without declaring what the command imports is broken, so this key
+# and `[project.scripts]` below are one decision: `init-repo --no-cli` removes both.
+dependencies = ["typer>=0.12"]
 
 [project.scripts]
-newpkg = "newpkg.cli:main"
+newpkg = "newpkg.cli:app"
 
 # ============================== build ==============================
 
@@ -55,6 +58,11 @@ liulab-newpkg = { path = ".", editable = true }
 # the price of the single pin, and it is cheap because all three share a solve group.
 [tool.pixi.dependencies]
 python = "3.13.*"
+# The one runtime dependency, mirrored from `[project] dependencies` so pixi takes it from
+# conda-forge instead of resolving it from PyPI. Both spellings are one decision and
+# `init-repo --no-cli` removes both: a repo that declined a command line must not install
+# the library only its command line imported.
+typer = ">=0.12"
 ruff = "*"
 # Pinned exactly: Pylance is pyright, so the editor and CI must give one verdict. Bumping
 # it is a deliberate, reviewed diff.

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -50,6 +50,11 @@ ROOT = Path(__file__).resolve().parent.parent
 #: `check` honest while it is still here.
 PLACEHOLDER = "new" + "pkg"
 
+#: The command line's framework. A rung that declined a command line must not name it anywhere,
+#: and only a grep sees the whole of that: two tables in `pyproject.toml` and the lock that pins
+#: them, each edited by a different anchor in `scripts/init_repo.py`.
+CLI_DEPENDENCY = "typer"
+
 #: The `PIXI_*` variables a parent `pixi run` exports. They name the TEMPLATE's manifest, and a
 #: nested pixi that inherited them would check this repo instead of the rendered one.
 PIXI_VARS = tuple(name for name in os.environ if name.startswith("PIXI_"))
@@ -168,6 +173,24 @@ def check_placeholder(stage: Path) -> list[str]:
     return problems
 
 
+def check_declined_cli(rung: Rung, stage: Path) -> list[str]:
+    """Grep a rung that ships no command line: nothing tracked may still name the framework.
+
+    Deleting `cli.py` and `[project.scripts]` is not enough. A repo that declined a command line
+    and still installs the library only that command line imported is carrying residue, and the
+    rendered repo's own gate cannot see it — `pixi install --locked` is happy either way.
+    """
+    if rung.cli:
+        return []
+    return [
+        f"{rel} still names {CLI_DEPENDENCY}, which only the command line used"
+        for rel in tracked_paths(stage)
+        if not (stage / rel).is_symlink()
+        and (stage / rel).is_file()
+        and CLI_DEPENDENCY.encode() in (stage / rel).read_bytes()
+    ]
+
+
 def check_shape(rung: Rung, stage: Path) -> list[str]:
     """Check what the rendered repo's own gate cannot see: which files are and are not there."""
     packaged = rung.shape != "no-package"
@@ -222,7 +245,7 @@ def render(rung: Rung, parent: Path) -> None:
     # reads `mkdocs.yml` and `docs/api.md` — both of which `init-repo` edits. `--strict` is in
     # the task, so a reference to a module this rung deleted fails here.
     run(["pixi", "run", "--locked", *manifest, "docs-build"], stage, label="pixi run docs-build")
-    problems = check_placeholder(stage) + check_shape(rung, stage)
+    problems = check_placeholder(stage) + check_shape(rung, stage) + check_declined_cli(rung, stage)
     if problems:
         raise RenderError("\n".join(f"    {problem}" for problem in problems))
 

--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -89,6 +89,16 @@ MARKED_BLOCKS = ((".github/workflows/ci.yml", "dogfood"), ("pyproject.toml", "do
 #: The task lines a repo with no package has no use for, matched whole.
 TASKS_A_PACKAGE_NEEDS = frozenset({'test = "pytest"', 'build = "python -m build"'})
 
+#: The command line's framework, and the three lines `pyproject.toml` declares it on: the wheel's
+#: own requirement, the comment introducing the conda mirror, and the mirror itself. A repo that
+#: declined a command line must not install the library only its command line imported, so all
+#: three go — and `drop_lock_dependency` takes the package out of `pixi.lock` with them.
+CLI_DEPENDENCY = "typer"
+CLI_PROJECT_COMMENT = "# The command line's framework, and the only"
+CLI_PROJECT_DEPENDENCY = f'dependencies = ["{CLI_DEPENDENCY}>=0.12"]'
+CLI_PIXI_COMMENT = "# The one runtime dependency, mirrored from"
+CLI_PIXI_DEPENDENCY = f'{CLI_DEPENDENCY} = ">=0.12"'
+
 #: Committing needs an identity, and a fresh runner has none configured.
 GIT_IDENTITY = ("-c", "user.name=init-repo", "-c", "user.email=init-repo@localhost")
 
@@ -328,6 +338,165 @@ def drop_lock_self_reference(text: str) -> str | None:
         kept.append(line)
         index += 1
     return "".join(kept) if changed else None
+
+
+def drop_cli_dependency(text: str) -> str | None:
+    """Remove the command line's framework from both of `pyproject.toml`'s dependency tables.
+
+    Declared twice on purpose — the wheel's own requirement, and the conda mirror pixi installs
+    from — so it has to be taken out twice. `[project] dependencies` is emptied rather than
+    deleted: the key is where the first real dependency goes, and a wheel with no dependencies
+    says so explicitly. Each declaration's comment goes with it — a note explaining a dependency
+    that is not there any more is the same residue as the dependency.
+    """
+    anchors: tuple[Callable[[str], str | None], ...] = (
+        lambda t: drop_comment_block(t, CLI_PROJECT_COMMENT),
+        lambda t: _replace(t, CLI_PROJECT_DEPENDENCY, "dependencies = []"),
+        lambda t: drop_comment_block(t, CLI_PIXI_COMMENT),
+        lambda t: drop_lines(t, lambda line: line.rstrip() == CLI_PIXI_DEPENDENCY),
+    )
+    edited = text
+    for anchor in anchors:
+        found = anchor(edited)
+        if found is None:
+            return None
+        edited = found
+    return edited
+
+
+def _lock_package_name(url: str) -> str:
+    """Read a conda package's name off its URL: the file name, less the version and the build."""
+    return url.rsplit("/", 1)[-1].rsplit("-", 2)[0]
+
+
+def _lock_pool(lines: list[str]) -> dict[str, tuple[str, set[str]]]:
+    """Map every conda package in the lock's pool to its name and the names it depends on.
+
+    The pool is the flat list at the end of the file — one entry per package, starting at column
+    zero, with its `depends:` block indented under it.
+    """
+    pool: dict[str, tuple[str, set[str]]] = {}
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if not line.startswith("- conda: "):
+            continue
+        url = line.removeprefix("- conda: ").strip()
+        depends: set[str] = set()
+        listing = False
+        while index < len(lines) and lines[index].startswith(" "):
+            entry = lines[index].rstrip()
+            index += 1
+            if entry == "  depends:":
+                listing = True
+            elif not entry.startswith("  - "):
+                listing = False
+            elif listing:
+                depends.add(entry.removeprefix("  - ").split()[0])
+        pool[url] = (_lock_package_name(url), depends)
+    return pool
+
+
+def _dropped_references(
+    lines: list[str], span: range, pool: dict[str, tuple[str, set[str]]], name: str
+) -> set[int]:
+    """Pick the lines of one environment's package list that go when `name` does.
+
+    `name` itself, then anything it reaches that nothing else in this environment still needs —
+    repeatedly, because a dependency of a dependency is an orphan too.
+    """
+    at: dict[str, int] = {}
+    needs: dict[str, set[str]] = {}
+    for index in span:
+        entry = pool.get(lines[index].strip().removeprefix("- conda: "))
+        if entry is None:
+            return set()
+        at[entry[0]], needs[entry[0]] = index, entry[1]
+    if name not in at:
+        return set()
+    reachable: set[str] = set()
+    stack = [name]
+    while stack:
+        for dependency in needs[stack.pop()]:
+            if dependency in needs and dependency not in reachable:
+                reachable.add(dependency)
+                stack.append(dependency)
+    doomed = {name}
+    while True:
+        orphans = {
+            package
+            for package in reachable - doomed
+            if not any(package in needs[other] for other in needs.keys() - doomed)
+        }
+        if not orphans:
+            return {at[package] for package in doomed}
+        doomed |= orphans
+
+
+def _is_lock_reference(line: str) -> bool:
+    """Whether this line lists a conda package in an environment, rather than defining one."""
+    return line.startswith(" ") and line.lstrip().startswith("- conda: ")
+
+
+def _drop_requirement(lines: list[str], name: str) -> list[str]:
+    """Remove one requirement from every `requires_dist` in the lock, and a key it empties."""
+    kept: list[str] = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        if line.rstrip() != "  requires_dist:":
+            kept.append(line)
+            continue
+        requirements = []
+        while index < len(lines) and lines[index].startswith("  - "):
+            if re.match(rf"  - {re.escape(name)}(?![\w.-])", lines[index]) is None:
+                requirements.append(lines[index])
+            index += 1
+        if requirements:
+            kept += [line, *requirements]
+    return kept
+
+
+def drop_lock_dependency(text: str, name: str) -> str | None:
+    """Remove one conda package from `pixi.lock`, along with whatever came in only for it.
+
+    A dependency taken out of `pyproject.toml` has to come out of here too: `pixi install
+    --locked` refuses a lock holding packages the manifest no longer asks for, and re-solving is
+    not an option — it needs the network, and a rendered repo installs from the lock it
+    inherited. What came in with the package is FOUND rather than listed, the way
+    `drop_unused_imports` asks whether a name is still used: everything the package reaches that
+    nothing else in that environment still needs goes with it, so a version bump that changes
+    its dependencies cannot leave this stale.
+    """
+    lines = _lines(text)
+    pool = _lock_pool(lines)
+    doomed: set[int] = set()
+    start: int | None = None
+    for index in range(len(lines) + 1):
+        if index < len(lines) and _is_lock_reference(lines[index]):
+            start = index if start is None else start
+        elif start is not None:
+            doomed |= _dropped_references(lines, range(start, index), pool, name)
+            start = None
+    kept = [line for index, line in enumerate(lines) if index not in doomed]
+
+    # The pool is shared by every environment, so an entry goes only once nothing lists it.
+    listed = {line.strip().removeprefix("- conda: ") for line in kept if _is_lock_reference(line)}
+    pruned: list[str] = []
+    index = 0
+    while index < len(kept):
+        line = kept[index]
+        index += 1
+        if line.startswith("- conda: ") and line.removeprefix("- conda: ").strip() not in listed:
+            while index < len(kept) and kept[index].startswith(" "):
+                index += 1
+            continue
+        pruned.append(line)
+
+    edited = "".join(_drop_requirement(pruned, name))
+    return edited if edited != text else None
 
 
 def _replace(text: str, old: str, new: str) -> str | None:
@@ -580,6 +749,24 @@ class Init:
             lambda text: drop_paragraph(text, "This is the Liu Lab repo template"),
         )
 
+    def prune_cli_dependency(self) -> None:
+        """Take the command line's framework out of the manifest and the lock, together.
+
+        Both shapes that ship no command line come through here — the one that declined it and
+        the one that has no package at all — because a repo carrying the library only its
+        command line imported is exactly the residue this template exists to prevent.
+        """
+        self.edit(
+            "pyproject.toml",
+            f"{CLI_DEPENDENCY}, in both dependency tables",
+            drop_cli_dependency,
+        )
+        self.edit(
+            "pixi.lock",
+            f"{CLI_DEPENDENCY} and the packages that came with it",
+            lambda text: drop_lock_dependency(text, CLI_DEPENDENCY),
+        )
+
     def prune_cli(self) -> None:
         """Take the command line out of a package that does not want one."""
         self.remove(f"src/{PLACEHOLDER_MODULE}/cli.py")
@@ -588,6 +775,7 @@ class Init:
             "[project.scripts]",
             lambda text: drop_toml_table(text, "[project.scripts]"),
         )
+        self.prune_cli_dependency()
         self.edit(
             "docs/api.md",
             "the command line reference",
@@ -651,6 +839,7 @@ class Init:
                 'include = ["scripts", "skills"]',
             ),
         )
+        self.prune_cli_dependency()
         self.edit("pixi.lock", "the editable install of this repo", drop_lock_self_reference)
         for job in ("test", "build"):
             self.edit(

--- a/src/newpkg/cli.py
+++ b/src/newpkg/cli.py
@@ -1,31 +1,29 @@
-"""The command line. One verb, so `[project.scripts]` has something to register."""
+"""The command line. One verb and a version, so `[project.scripts]` has something to register.
 
-import argparse
-from collections.abc import Sequence
+Typer, because every lab repo that ships a command line uses it: one `typer.Typer` named
+`app`, `no_args_is_help=True` so a bare invocation prints help instead of nothing, and a
+`version` command. A larger surface grows by mounting sub-apps with `app.add_typer`.
+"""
 
-from newpkg import __version__
-from newpkg.core import greet
+from typing import Annotated
+
+import typer
+
+from newpkg import __version__ as _package_version
+from newpkg.core import greet as _greet
+
+#: What `[project.scripts]` registers. Typer builds the parser from the signatures below, so
+#: a verb is a function and its help is the docstring.
+app = typer.Typer(help="The placeholder command.", no_args_is_help=True)
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    """Run the command line.
+@app.command()
+def version() -> None:
+    """Print the installed package version."""
+    typer.echo(_package_version)
 
-    Parameters
-    ----------
-    argv
-        Arguments to parse. `None` reads `sys.argv`.
 
-    Returns
-    -------
-    int
-        The process exit code.
-    """
-    parser = argparse.ArgumentParser(prog="newpkg", description="The placeholder command.")
-    parser.add_argument("--version", action="version", version=__version__)
-    verbs = parser.add_subparsers(dest="verb", required=True)
-    hello = verbs.add_parser("greet", help="Print a greeting.")
-    hello.add_argument("name", nargs="?", default="world", help="Who to greet.")
-
-    args = parser.parse_args(argv)
-    print(greet(args.name))
-    return 0
+@app.command()
+def greet(name: Annotated[str, typer.Argument(help="Who to greet.")] = "world") -> None:
+    """Print a greeting addressed to NAME."""
+    typer.echo(_greet(name))

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,9 +1,9 @@
 """The placeholder's own test. Rename it with the module."""
 
-import pytest
+from typer.testing import CliRunner
 
 from newpkg import __version__, greet
-from newpkg.cli import main
+from newpkg.cli import app
 
 
 def test_greet_addresses_the_name_it_is_given() -> None:
@@ -19,6 +19,7 @@ def test_version_comes_from_the_installed_metadata() -> None:
     assert __version__
 
 
-def test_the_cli_verb_prints_the_greeting(capsys: pytest.CaptureFixture[str]) -> None:
-    assert main(["greet", "lab"]) == 0
-    assert capsys.readouterr().out.strip() == "Hello, lab!"
+def test_the_cli_verb_prints_the_greeting() -> None:
+    result = CliRunner().invoke(app, ["greet", "lab"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "Hello, lab!"


### PR DESCRIPTION
Closes #33.

`src/newpkg/cli.py` was argparse. Every lab repo that ships a command line — `seqforge`,
`liulab-data`, `liulab-genome` — uses typer, and all three agree on the idiom, so the placeholder
now matches it: `app = typer.Typer(help=..., no_args_is_help=True)`, a `version` command, one
`greet` verb, `typer>=0.12` in `[project] dependencies` and mirrored into
`[tool.pixi.dependencies]`, and `[project.scripts] newpkg = "newpkg.cli:app"`.

## What was harder than a file swap

- **`--no-cli` had to remove the dependency.** `prune_cli` empties `[project] dependencies` and
  drops the conda mirror, each with the comment that explains it. `prune_package` does the same,
  because the `no-package` shape never runs `prune_cli` and has no command line either.
- **`pixi.lock` had to lose it too.** `pixi install --locked` refuses a lock holding packages the
  manifest no longer asks for, so a stale lock would have failed the rendered repo's own CI on
  its first push. `drop_lock_dependency` removes the package, the packages that came in with it
  that nothing else in that environment still needs, and its line in the local package's
  `requires_dist`. Those companions are found rather than listed, so bumping typer cannot leave
  the list stale.
- **`dogfood` asserts it.** Both rungs that ship no command line are grepped: no tracked file may
  name typer. Verified against a failing fixture.
- **`docs/api.md`** points at `newpkg.cli` — the whole module — because typer leaves each verb a
  plain function with a docstring. Confirmed by reading the built HTML, not by assuming.

## Verified

`pixi run check` green (six static steps, all conformance rules, 31 tests), `pixi run dogfood`
green on all three rungs, `pixi run docs-build` clean, `pixi lock --check` up to date, and the
built wheel declares `Requires-Dist: typer>=0.12` with `newpkg = newpkg.cli:app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KjyNJqzk8ScAUR12gECaf