### PR TITLE
Keep the template's own records out of derived repos (#34)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ pixi run docs-build
 | `scripts/check.sh` | the gate every commit has to pass |
 | `CONTEXT.md` | the glossary: the words this repo uses |
 
-Some notes are written for coding agents, not for people. They live under `docs/agents/`,
-`docs/adr/` and `docs/research/`. You will not find them in the menu or the search box,
-but the links to them still work.
+Some notes are written for coding agents, not for people. Conventions go under
+`docs/agents/`, decision records under `docs/adr/`, and research notes under
+`docs/research/`. Nothing in those three directories shows up in the menu or the search
+box, and a page written there is still reachable by its own URL.

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -55,6 +55,17 @@ PLACEHOLDER = "new" + "pkg"
 #: them, each edited by a different anchor in `scripts/init_repo.py`.
 CLI_DEPENDENCY = "typer"
 
+#: The template's own records — how it chose its docs site, and the evidence behind the rules it
+#: ships. Spelled out here rather than imported from `scripts/init_repo.py`, for the reason the
+#: two constants above are: an assertion that reads its expectation out of the thing it is
+#: checking cannot tell a deletion that ran from a list that quietly lost an entry.
+TEMPLATE_RECORDS = (
+    "docs/adr/0001-docs-site-on-zensical.md",
+    "docs/research/github-template-mechanics-2026-08-30.md",
+    "docs/research/vale-setup-2026-08-30.md",
+    "docs/research/zensical-viability-2026-08-30.md",
+)
+
 #: The `PIXI_*` variables a parent `pixi run` exports. They name the TEMPLATE's manifest, and a
 #: nested pixi that inherited them would check this repo instead of the rendered one.
 PIXI_VARS = tuple(name for name in os.environ if name.startswith("PIXI_"))
@@ -191,6 +202,49 @@ def check_declined_cli(rung: Rung, stage: Path) -> list[str]:
     ]
 
 
+def check_template_records(stage: Path) -> list[str]:
+    """Grep a rendered repo for the template's own records, as a path and as a citation.
+
+    None of the four is about the repo that inherited it, and the rendered repo's own gate is
+    happy either way — a stale ADR passes every rule the template propagates. Citations are
+    checked with the paths because a comment pointing at a document that is not there is the
+    same residue as the document, spread over more files.
+    """
+    tracked = tracked_paths(stage)
+    problems = [
+        f"{record} is the template's own record and is still tracked"
+        for record in TEMPLATE_RECORDS
+        if record in tracked
+    ]
+    for rel in tracked:
+        path = stage / rel
+        if path.is_symlink() or not path.is_file():
+            continue
+        body = path.read_bytes()
+        problems += [
+            f"{rel} still points at {record}, which this repo does not have"
+            for record in TEMPLATE_RECORDS
+            if record.encode() in body
+        ]
+    return problems
+
+
+def check_changelog(stage: Path) -> list[str]:
+    """Read the rendered changelog: it keeps its preamble and none of the template's entries.
+
+    The file itself is never subtracted — conformance rule 8 wants one wherever `release.yml`
+    is — so what is asserted is its CONTENTS. Every Keep a Changelog entry is a list item, so
+    asking whether any list item survived tests the shape rather than the template's current
+    wording, and an entry added to this repo tomorrow cannot make this pass on nothing.
+    """
+    text = (stage / "CHANGELOG.md").read_text(encoding="utf-8")
+    return [
+        f"CHANGELOG.md still carries a template entry: {line.strip()}"
+        for line in text.splitlines()
+        if line.lstrip().startswith(("- ", "* ", "+ "))
+    ]
+
+
 def check_shape(rung: Rung, stage: Path) -> list[str]:
     """Check what the rendered repo's own gate cannot see: which files are and are not there."""
     packaged = rung.shape != "no-package"
@@ -212,7 +266,8 @@ def check_shape(rung: Rung, stage: Path) -> list[str]:
         "src": packaged,
         "tests": packaged,
         "docs/api.md": packaged,
-        # Never subtracted, at any rung.
+        # Never subtracted, at any rung. `check_changelog` asks the other half of that: the
+        # file ships, and the entries under its heading are this repo's or nobody's.
         "CHANGELOG.md": True,
         "AGENTS.md": True,
         "CONTEXT.md": True,
@@ -245,7 +300,13 @@ def render(rung: Rung, parent: Path) -> None:
     # reads `mkdocs.yml` and `docs/api.md` — both of which `init-repo` edits. `--strict` is in
     # the task, so a reference to a module this rung deleted fails here.
     run(["pixi", "run", "--locked", *manifest, "docs-build"], stage, label="pixi run docs-build")
-    problems = check_placeholder(stage) + check_shape(rung, stage) + check_declined_cli(rung, stage)
+    problems = (
+        check_placeholder(stage)
+        + check_shape(rung, stage)
+        + check_declined_cli(rung, stage)
+        + check_template_records(stage)
+        + check_changelog(stage)
+    )
     if problems:
         raise RenderError("\n".join(f"    {problem}" for problem in problems))
 

--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -22,8 +22,11 @@ Actions come in two kinds, and only one of them is dangerous:
   asked the person.
 
 Exempt from that check, deleted unconditionally and tolerated when absent: the two skill
-directories, their four symlinks, the `dogfood` job and its task, `scripts/dogfood.py`, and
-this file. Their removal is the entire point, so nothing about them is negotiable.
+directories, their four symlinks, the `dogfood` job and its task, `scripts/dogfood.py`, this
+file, and the template's own records — the ADR and the three research notes that say how the
+template was built. Their removal is the entire point, so nothing about them is negotiable.
+`CHANGELOG.md` is the one record handled the other way: the file always ships, and emptying it
+of the template's entries is guarded, so a late init never discards what someone wrote.
 
 Everything else is an ANCHORED edit: it matches text the template ships and reports a miss
 rather than failing. A repo that rewrote the passage keeps what it wrote, and the one thing
@@ -61,7 +64,8 @@ PLACEHOLDER_DIST = f"liulab-{PLACEHOLDER_MODULE}"
 PLACEHOLDER_DESCRIPTION = "One line: what this repo is for. `init-repo` rewrites this."
 
 #: Three rungs on one ladder. `published` subtracts nothing, `not-published` drops the release
-#: workflow, `no-package` also drops `src/` and `tests/`. `CHANGELOG.md` survives all three.
+#: workflow, `no-package` also drops `src/` and `tests/`. The `CHANGELOG.md` FILE survives all
+#: three; its entries do not, which is a different question and `CHANGELOG_UNRELEASED` answers it.
 SHAPES = ("published", "not-published", "no-package")
 
 #: Used when a remote is a local path rather than a GitHub URL, which is what a scratch clone
@@ -80,6 +84,47 @@ TEMPLATE_ONLY = (
     "scripts/dogfood.py",
     "scripts/init_repo.py",
 )
+
+#: The template's own records: the decision it made about its docs site, and the three notes
+#: behind the rules it ships. Same category as the two skills above — machinery whose removal is
+#: the point — so they go the same way, unconditionally and tolerated when absent.
+#:
+#: BY EXACT PATH, never by directory or glob. A repo initialized late may already have written
+#: `docs/adr/0002-*.md` or a research note of its own, and deleting `docs/adr/` would take it
+#: with these. Both directories are allowed to disappear with their last file: `Repo.delete`
+#: prunes what it empties, and `docs/agents/domain.md` says `/domain-modeling` creates
+#: `docs/adr/` when it needs one and that a missing one is not an error. No `.gitkeep` — a
+#: tracked file whose only job is to exist is exactly the residue this script removes.
+TEMPLATE_ADR = "docs/adr/0001-docs-site-on-zensical.md"
+TEMPLATE_VALE_NOTE = "docs/research/vale-setup-2026-08-30.md"
+TEMPLATE_RECORDS = (
+    TEMPLATE_ADR,
+    "docs/research/github-template-mechanics-2026-08-30.md",
+    TEMPLATE_VALE_NOTE,
+    "docs/research/zensical-viability-2026-08-30.md",
+)
+
+#: Every citation of a record above that lives in a file a derived repo KEEPS, and what the
+#: sentence becomes once the citation goes. Deleting a document and leaving five files pointing
+#: at it trades one kind of residue for a worse one, so each citation is cut where it stands
+#: rather than the paragraph explaining the rule around it.
+RECORD_POINTERS = (
+    ("mkdocs.yml", f"# See {TEMPLATE_ADR}.\n", ""),
+    (".github/workflows/docs.yml", f" See `{TEMPLATE_ADR}`.", ""),
+    ("pyproject.toml", f" (`{TEMPLATE_VALE_NOTE}`)", ""),
+    ("styles/Lab/Readability.yml", f" See `{TEMPLATE_VALE_NOTE}`.", ""),
+    (
+        "styles/Lab/Jargon.yml",
+        f"# The measurements and the per-pattern evidence are in\n# `{TEMPLATE_VALE_NOTE}`. Do not",
+        "# Do not",
+    ),
+)
+
+#: The heading the changelog is reset to. Everything below it is the TEMPLATE's history — one
+#: entry even describes the release workflow the lower two rungs delete — and none of it is the
+#: new repo's. Truncating at the heading keeps the preamble, which is the part that says what
+#: format to write in, and keeps this file from holding a second copy of it to drift from.
+CHANGELOG_UNRELEASED = "## [Unreleased]"
 
 #: Files carrying an `init-repo:begin dogfood` / `init-repo:end dogfood` pair. The dogfood job
 #: cannot be deleted by path — it is one job inside a workflow every repo keeps — so it ships as
@@ -186,6 +231,15 @@ def drop_comment_block(text: str, prefix: str) -> str | None:
     while end < len(lines) and lines[end].lstrip().startswith("#"):
         end += 1
     return _cut(lines, start, end)
+
+
+def truncate_at(text: str, heading: str) -> str | None:
+    """Keep everything down to and including this heading, and drop what is under it."""
+    lines = _lines(text)
+    start = _find(lines, lambda line: line.rstrip() == heading)
+    if start is None:
+        return None
+    return "".join(lines[: start + 1])
 
 
 def drop_marked_block(text: str, name: str) -> str | None:
@@ -687,7 +741,13 @@ class Init:
 
     def survey(self) -> None:
         """Decide, before anything changes, which deletions and overwrites may run."""
-        targets = [Guarded("README.md", "rewrite", "it describes the template, not this repo")]
+        targets = [
+            Guarded("README.md", "rewrite", "it describes the template, not this repo"),
+            # The FILE is never subtracted — rule 8 wants one wherever `release.yml` is — but its
+            # entries are the template's history. Guarded, and only here: a repo initialized
+            # eight months late has real entries under that heading, and they are not ours to cut.
+            Guarded("CHANGELOG.md", "reset", "its entries are the template's, not this repo's"),
+        ]
         if self.identity.shape != "published":
             targets.append(
                 Guarded(".github/workflows/release.yml", "delete", "this repo does not publish")
@@ -726,7 +786,7 @@ class Init:
 
     def remove_template_only(self) -> None:
         """Delete the artifacts whose removal is the point, wherever they still are."""
-        for rel in TEMPLATE_ONLY:
+        for rel in (*TEMPLATE_ONLY, *TEMPLATE_RECORDS):
             self.remove(rel)
         for rel, name in MARKED_BLOCKS:
             self.edit(rel, f"the {name} block", lambda text, n=name: drop_marked_block(text, n))
@@ -748,6 +808,12 @@ class Init:
             "the paragraph about the template",
             lambda text: drop_paragraph(text, "This is the Liu Lab repo template"),
         )
+        for rel, old, new in RECORD_POINTERS:
+            self.edit(
+                rel,
+                "the citation of a record this repo does not keep",
+                lambda text, o=old, n=new: _replace(text, o, n),
+            )
 
     def prune_cli_dependency(self) -> None:
         """Take the command line's framework out of the manifest and the lock, together.
@@ -966,6 +1032,16 @@ class Init:
             return
         self.repo.write("README.md", readme(self.identity))
         self.say("wrote", "README.md")
+
+    def reset_changelog(self) -> None:
+        """Empty the changelog of the template's entries, keeping the file and its preamble."""
+        if not self.approved("CHANGELOG.md"):
+            return
+        self.edit(
+            "CHANGELOG.md",
+            "the template's own entries",
+            lambda text: truncate_at(text, CHANGELOG_UNRELEASED),
+        )
 
     def commit(self, *, do_commit: bool) -> None:
         """Stage everything, and record it as one commit."""
@@ -1217,6 +1293,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         init.say("skipped", "the rename — nothing tracked names the placeholder any more")
     init.describe()
     init.write_readme()
+    init.reset_changelog()
 
     if init.misses:
         print("\n  what it left alone\n")

--- a/skills/init-repo/SKILL.md
+++ b/skills/init-repo/SKILL.md
@@ -110,5 +110,5 @@ Repeat the script's `next` list, and be clear about the two things it cannot do:
   not publish.
 
 Say what the script deliberately left behind, so nobody mistakes it for this repo's own:
-`CHANGELOG.md` still holds the template's entries, and the placeholder `greet()` and its
-test are still in the package until real code replaces them.
+the placeholder `greet()` and its test stay in the package until real code replaces them.
+`CHANGELOG.md` is emptied down to its heading, so the first entry under it is theirs.

--- a/skills/template-dev/SKILL.md
+++ b/skills/template-dev/SKILL.md
@@ -44,13 +44,30 @@ forever.
 
 `init-repo` **subtracts**. It deletes this skill, the `init-repo` skill, their symlinks,
 and the CI job that renders the template. A repo that does not publish loses the release
-workflow; a repo with no package also loses `src/` and `tests/`. `CHANGELOG.md` is never
-subtracted.
+workflow; a repo with no package also loses `src/` and `tests/`. The `CHANGELOG.md` file
+is never subtracted.
 
 Before adding anything, decide which side of that line it is on. Template-only machinery
 must be **deletable by path**, and no file a derived repo keeps may name it — a pointer in
 a surviving file turns into a dangling reference in fifty repos. Generic files must not
 mention this skill, the dogfood job, or anything else that will not be there.
+
+## The records stay here
+
+This repo's ADR and its research notes are the same category as this skill: they say how
+the **template** was built, and none of it is a decision the new repo made. `init-repo`
+deletes all four, and cuts every citation of them out of the files a derived repo keeps —
+`mkdocs.yml`, `docs.yml`, `pyproject.toml` and two rules in `styles/Lab/`.
+
+So write a record here freely, and when you cite one, expect to add the cut with it.
+Deletion is **by exact path**, never by directory: a repo initialized late may have
+written `docs/adr/0002-*.md` already, and `docs/adr/` is allowed to disappear when its
+last file does. No `.gitkeep` — `/domain-modeling` makes the directory when it needs one.
+
+`CHANGELOG.md` is the exception that proves the shape. The file always ships, because a
+repo that publishes needs one, but its entries are this template's history, so they are
+emptied out — guarded by the untouched check, so a late init never cuts real entries. Add
+an entry here for anything worth knowing about; it does not travel.
 
 ## Changing a shared convention
 


### PR DESCRIPTION
Closes #34.

A repo made from the template inherited four documents describing how *the template* was built,
plus a changelog of the template's history. `init_repo.py` already deletes `skills/init-repo/`
and `skills/template-dev/` as template-only artifacts; these are the same category and were
missed because the spec's manifest lists `docs/` as one line.

## What changed

**Deleted by exact path, at every rung, tolerating absence** — `docs/adr/0001-docs-site-on-zensical.md`
and the three `docs/research/*.md` notes join `TEMPLATE_ONLY` in `remove_template_only()`. By path
and never by directory: a repo initialized late may already have written `docs/adr/0002-*.md` or a
note of its own, and deleting `docs/adr/` would take it. Both directories are allowed to vanish
with their last file (`Repo.delete` already prunes what it empties), so there is no `.gitkeep` —
`docs/agents/domain.md` says `/domain-modeling` creates `docs/adr/` lazily and that a missing one
is not an error. `docs/agents/*.md` still ships: lab conventions, not template record.

**Citations go with the documents.** Five files a derived repo keeps pointed at a record that is
now gone. `RECORD_POINTERS` cuts each citation where it stands, in the anchored-edit style:
`mkdocs.yml`, `.github/workflows/docs.yml`, `pyproject.toml`, `styles/Lab/Readability.yml`,
`styles/Lab/Jargon.yml`. `skills/template-dev/SKILL.md` already required this — "no file a derived
repo keeps may name it".

**`CHANGELOG.md` is reset, not deleted.** The file is never subtracted (rule 8 wants one wherever
`release.yml` is), but its entries are the template's history — one describes the `release.yml`
that rungs 2 and 3 delete. `truncate_at()` cuts everything below `## [Unreleased]`, keeping the
preamble so the derived repo still says what format to write in and no second copy of that text
exists to drift. The reset is **guarded by the untouched check** — it joins the guarded set beside
`README.md` — so a late init never discards real entries.

**`docs/index.md`** claimed "the links to them still work", which is false in a repo where both
directories are empty. It now states the convention (where each kind of note goes) rather than
claiming files exist, so it is true in the template and in a derived repo alike. No anchored edit
was needed — the shipped text is true both ways, which is one less thing that can miss.

**`skills/template-dev/SKILL.md`** gets a "The records stay here" section: write records here
freely, expect to add the cut when you cite one, deletion is by exact path, and the changelog is
the exception that proves the shape. 868 words by Vale's count, cap 1000.

## Verification

- `pixi run check` — green (6 static steps + 31 tests)
- `pixi run dogfood` — green, all three rungs
- `pixi run docs-build` — `No issues found`

**The new assertions are not vacuous.** Each was run against a deliberately disabled prune:

| disabled | dogfood output |
| --- | --- |
| record deletion | `docs/adr/0001-docs-site-on-zensical.md is the template's own record and is still tracked` (and the three notes) |
| `RECORD_POINTERS` | `mkdocs.yml still points at docs/adr/0001-docs-site-on-zensical.md, which this repo does not have` (and four more) |
| `reset_changelog()` | `CHANGELOG.md still carries a template entry: - The placeholder package, the pixi workspace, and the three environments.` (and five more) |

**`pixi.lock` is untouched**, verified rather than assumed: the branch diff contains no `pixi.lock`,
no record path appears in the lock, and the lock a `no-package` render produces — the rung that
edits the lock most, via #33's `drop_lock_dependency` — is byte-identical between `main`'s
`init_repo.py` and this branch's.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KjyNJqzk8ScAUR12gECaf