### PR TITLE
Trim the config comments to what is load-bearing

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,47 +1,15 @@
-# Vale configuration. The rules themselves live in styles/Lab/, tracked in this repo —
-# no Packages and no `vale sync`, because four rules do not justify a release process and
-# a template is copied. `styles/` is therefore NOT in .gitignore, which is the opposite of
-# the usual convention for StylesPath.
+# Rules live in styles/Lab/, tracked — so `styles/` is not in .gitignore.
 #
-# ---------------------------------------------------------------------------------------
-# EVERY RULE IS NAMED IN EVERY SECTION. This is not style; it is the only thing that makes
-# the table below true.
-#
-# Vale's `*` matches `/`, so `docs/**/*.md` also matches `docs/adr/0001-x.md`. More than
-# one section therefore matches the same file, and Vale *accumulates* per-rule settings
-# across every matching section, later sections winning. `BasedOnStyles` replaces; named
-# rules accumulate. An omitted rule is not "default on" — it keeps whatever an earlier
-# section said. Leave `Lab.LengthAdr` out of section 3 and ADRs inherit `= NO` from
-# section 1 and are checked by NOTHING, with zero alerts and green CI. That exact failure
-# already happened once while this repo was being designed.
-#
-# So: four sections, four rules, sixteen lines. Adding a rule means adding it to all four.
-#
-# SECTION ORDER IS LOAD-BEARING, and it is stable — the later section wins, every time
-# (verified on vale 3.19.0 over 160 runs of a config whose two sections disagree). The
-# broad section must therefore come first and the narrow ones after it. Moving section 1
-# to the bottom silently re-enables jargon and readability on every ADR and research note.
-#
-# Each key of [tool.liulab.agent-docs] appears verbatim in one section header above —
-# `AGENTS.md`, `CONTEXT.md`, `docs/agents/`, `skills/`, `docs/adr/`, `docs/research/` — so
-# conformance can pair a key with its section by substring. Keep it that way.
-#
-# | section                                                       | Jargon | Read. | Length    |
-# | ------------------------------------------------------------- | ------ | ----- | --------- |
-# | 1  README.md, CHANGELOG.md, human docs/                        | YES    | YES   | none      |
-# | 2  AGENTS.md, CONTEXT.md, docs/agents/, skills/*/SKILL.md      | NO     | NO    | LengthDoc |
-# | 3  docs/adr/                                                   | NO     | NO    | LengthAdr |
-# | 4  docs/research/                                              | NO     | NO    | none      |
-#
-# The table is also written for humans in docs/agents/writing.md; the two must agree.
-# ---------------------------------------------------------------------------------------
+# EVERY RULE IS NAMED IN EVERY SECTION. Vale's `*` matches `/`, so sections overlap and
+# per-rule settings accumulate, later sections winning. An omitted rule keeps whatever an
+# earlier section said, which once left ADRs checked by nothing on green CI. Broad section
+# first. Each [tool.liulab.agent-docs] key appears verbatim in one header below; conformance
+# rule 3 pairs them by substring. The caps are explained in docs/agents/writing.md.
 
 StylesPath = styles
 MinAlertLevel = error
 
-# --- 1. Human-facing -------------------------------------------------------------------
-# Everything a person browsing the published site reads. No length cap: a tutorial is as
-# long as the task. Sections 2-4 come after this one and carve their files back out of it.
+# 1. Human-facing: the published site. Uncapped.
 [{README.md,CHANGELOG.md,docs/**/*.md}]
 BasedOnStyles = Lab
 Lab.Jargon = YES
@@ -49,9 +17,7 @@ Lab.Readability = YES
 Lab.LengthDoc = NO
 Lab.LengthAdr = NO
 
-# --- 2. Agent-facing documents ---------------------------------------------------------
-# Written for a machine that has to act. Word budget only: jargon and reading grade are
-# off because the audience is not a person skimming a website.
+# 2. Agent-facing: word budget only.
 [{AGENTS.md,CONTEXT.md,docs/agents/**/*.md,skills/**/SKILL.md}]
 BasedOnStyles = Lab
 Lab.Jargon = NO
@@ -59,9 +25,7 @@ Lab.Readability = NO
 Lab.LengthDoc = YES
 Lab.LengthAdr = NO
 
-# --- 3. Decision records ---------------------------------------------------------------
-# Agent-facing, on the tighter 400-word cap. `Lab.LengthAdr = YES` here and
-# `Lab.LengthDoc = NO` are both load-bearing: section 1 already matched this file.
+# 3. Decision records: the tighter cap.
 [docs/adr/**/*.md]
 BasedOnStyles = Lab
 Lab.Jargon = NO
@@ -69,15 +33,8 @@ Lab.Readability = NO
 Lab.LengthDoc = NO
 Lab.LengthAdr = YES
 
-# --- 4. Research notes -----------------------------------------------------------------
-# Uncapped by decision: a note is as long as what was found.
-#
-# Jargon and readability are off here too, and that is deliberate rather than an
-# oversight. A research note quotes the thing it is arguing against — the note that
-# defines this jargon map lists every banned phrase, in full, as evidence. Checking the
-# rule against its own source would fire twenty alerts on a document that is doing exactly
-# what it should. These notes are also agent-facing: they are excluded from the site's nav
-# and search, so no one browses them expecting readable prose.
+# 4. Research notes: uncapped, and exempt from jargon because a note quotes what it argues
+# against — the note defining the jargon map lists every banned phrase as evidence.
 [docs/research/**/*.md]
 BasedOnStyles = Lab
 Lab.Jargon = NO

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
-# hatch-vcs reads the newest git tag. Never add a `version` key here.
+# hatch-vcs reads the newest git tag. Never add a `version` key.
 dynamic = ["version"]
-# The command line's framework, and the only runtime dependency the placeholder has. A wheel
-# that registers a command without declaring what the command imports is broken, so this key
-# and `[project.scripts]` below are one decision: `init-repo --no-cli` removes both.
 dependencies = ["typer>=0.12"]
 
 [project.scripts]
@@ -32,9 +29,7 @@ newpkg = "newpkg.cli:app"
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
-# No `fallback-version`: it is a hand-written version string, which is the thing this
-# repo does not do. With no tag yet, setuptools-scm reports `0.1.devN+g<sha>`, and
-# `init-repo` pushes `v0.0.0` so a new repo does not read as if a release happened.
+# No `fallback-version`: that is a hand-written version string.
 [tool.hatch.version]
 source = "vcs"
 
@@ -50,66 +45,43 @@ platforms = ["osx-arm64", "linux-64"]
 [tool.pixi.pypi-dependencies]
 liulab-newpkg = { path = ".", editable = true }
 
-# Python is pinned HERE and nowhere else — there is no `py313` feature — so every
-# environment inherits one interpreter and nothing can claim a version it does not run.
-# `requires-python` above is the only other place a version appears.
-#
-# The static gate's tools go in this table too. Every environment inherits them; that is
-# the price of the single pin, and it is cheap because all three share a solve group.
+# Python is pinned here and nowhere else; `requires-python` is its only other mention.
+# Runtime dependencies are mirrored from `[project] dependencies` so pixi takes them from
+# conda-forge rather than PyPI.
 [tool.pixi.dependencies]
 python = "3.13.*"
-# The one runtime dependency, mirrored from `[project] dependencies` so pixi takes it from
-# conda-forge instead of resolving it from PyPI. Both spellings are one decision and
-# `init-repo --no-cli` removes both: a repo that declined a command line must not install
-# the library only its command line imported.
 typer = ">=0.12"
 ruff = "*"
-# Pinned exactly: Pylance is pyright, so the editor and CI must give one verdict. Bumping
-# it is a deliberate, reviewed diff.
+# Exact: Pylance is pyright, so the editor and CI must give one verdict.
 pyright = "==1.1.411"
 python-build = "*"
-# Pinned to the version the jargon map and the grade-11 readability number were measured
-# against (`docs/research/vale-setup-2026-08-30.md`). A minor bump can change the metric
-# semantics, which would move the gate without anyone editing a rule.
+# Exact: the jargon map and the grade-11 number were measured against this version.
 vale = "3.19.0.*"
 markdownlint-cli2 = "*"
-# `scripts/conformance.py` reads `mkdocs.yml` and the front matter of every agent-facing page,
-# so the DEFAULT environment needs a YAML parser. It goes here rather than on a feature because
-# conformance is a step of `check-static`, which runs in `default`.
+# For conformance, which parses mkdocs.yml and runs in `default`.
 pyyaml = "*"
 
 [tool.pixi.feature.test.dependencies]
 pytest = "*"
 
-# zensical is pinned EXACTLY, not to a range. At 0.0.x nothing promises that 0.0.58 is
-# compatible, and 0.0.48 shipped a regression that broke search and was hotfixed hours
-# later. Bump it deliberately and re-run `docs-build`.
+# Exact: at 0.0.x nothing promises the next patch is compatible.
 [tool.pixi.feature.docs.dependencies]
 zensical = "==0.0.57"
 mkdocstrings-python = ">=2.0.7,<3"
 
-# These live on the `docs` feature, not in [tool.pixi.tasks], so they run in the `docs`
-# environment — the one place zensical is installed. `pixi run docs-build` finds them
-# there without an `-e` flag. The docs build is NOT a step of `check`: this environment is
-# the heaviest one, and it gets its own CI job for that reason.
-#
-# `serve` takes `--strict` but prints "Strict mode is currently unsupported" and ignores
-# it, so it is omitted. `--clean` matches the workflow zensical's own docs publish with.
+# On the feature, so these resolve in the `docs` environment with no `-e` flag.
+# `serve` ignores `--strict` and says so, hence its absence.
 [tool.pixi.feature.docs.tasks]
 docs = "zensical serve"
 docs-build = "zensical build --clean --strict"
 
-# `default` takes `test` so pyright can resolve pytest when it type-checks `tests/`, and
-# deliberately does NOT take `docs`: the docs environment is the heaviest one and exists so
-# that exactly one CI job installs it. All three share a solve group, so a version cannot
-# differ between the suite, the site and the editor. Write docs from `pixi shell -e docs`.
+# `default` takes `test` so pyright can resolve pytest, and not `docs`, which exists so that
+# exactly one CI job installs it.
 [tool.pixi.environments]
 default = { features = ["test"], solve-group = "default" }
 test = { features = ["test"], solve-group = "default" }
 docs = { features = ["docs"], solve-group = "default" }
 
-# One task per gate step. `check` and `check-static` land with `scripts/check.sh`, which
-# runs the static steps concurrently and reports every failure rather than the first.
 [tool.pixi.tasks]
 lint = "ruff check ."
 fmt = "ruff format ."
@@ -117,25 +89,16 @@ fmt-check = "ruff format --check ."
 typecheck = "pyright"
 test = "pytest"
 build = "python -m build"
-# `.` and not an absolute path: vale matches its `.vale.ini` globs against the filename
-# exactly as passed, so an absolute path matches no section, raises no alert and exits 0 —
-# a gate that is silently switched off. pixi runs tasks from the workspace root, so `.`
-# expands to repo-relative names and every section applies.
+# `.`, never an absolute path: an absolute path matches no `.vale.ini` section and exits 0.
 vale = "vale ."
 markdownlint = "markdownlint-cli2"
-# The rules every Liu Lab repo keeps after it leaves the template. It reads
-# [tool.liulab.agent-docs] and [tool.liulab.waived] below.
 conformance = "python scripts/conformance.py"
-# The static step list exists HERE and nowhere else — `check.sh` takes it as arguments —
-# so the local gate and CI cannot drift. Adding a step is one more word on this line.
+# The static step list lives here and nowhere else; `check.sh` takes it as arguments.
 check-static = "bash scripts/check.sh lint fmt-check typecheck vale markdownlint conformance"
 check = { depends-on = ["check-static", "test"] }
 # init-repo:begin dogfood
-# TEMPLATE-ONLY. `scripts/init_repo.py` deletes everything between these two markers, and the
-# matching block at the end of `ci.yml`. It renders this template for all three shapes into
-# scratch repos and runs each result's own gate, so a change to the tree cannot quietly break
-# repo creation. It is NOT a step of `check`: it installs three pixi environments and takes
-# minutes, and the gate has to stay something you run before every commit.
+# Markers read by `scripts/init_repo.py`, which deletes this block and its twin in ci.yml.
+# Template-only, and not a step of `check`: it installs three environments and takes minutes.
 dogfood = "python scripts/dogfood.py"
 # init-repo:end dogfood
 
@@ -144,8 +107,7 @@ dogfood = "python scripts/dogfood.py"
 [tool.ruff]
 line-length = 100
 src = ["src", "tests", "scripts"]
-# No `target-version`. Ruff infers it from `requires-python`, so the linted version and
-# the installed version cannot disagree.
+# No `target-version`: ruff infers it from `requires-python`.
 extend-exclude = [".pixi", "site", "build", "dist"]
 
 [tool.ruff.lint]
@@ -176,15 +138,12 @@ convention = "numpy"
 # ============================== pyright ==============================
 
 [tool.pyright]
-# `scripts` and `skills` are in scope, not just the package. They were left out at first, which
-# made `skills/install.py` and `scripts/conformance.py` — the two files that CI and a conformance
-# rule EXECUTE — the only tracked Python nothing type-checked. Every one of these files is clean
-# at `standard` today, so the wider scope costs nothing and keeps the gate honest.
+# `scripts` and `skills` included: CI and conformance execute those files.
 include = ["src", "tests", "scripts", "skills"]
 exclude = ["**/__pycache__", "**/.pixi"]
 venvPath = ".pixi/envs"
 venv = "default"
-# No `pythonVersion`: pyright takes it from the interpreter in the environment above.
+# No `pythonVersion`: taken from the interpreter in the environment above.
 typeCheckingMode = "standard"
 useLibraryCodeForTypes = true
 reportMissingTypeStubs = "none"
@@ -198,20 +157,10 @@ xfail_strict = true
 filterwarnings = ["error"]
 
 # ============================== liulab ==============================
-# Read by `scripts/conformance.py`. See its docstring for what each rule requires.
+# Read by `scripts/conformance.py`; its docstring has the rules.
 
-# THE declared agent-facing set — one list, every consumer reads it. Two lists that must match
-# drifted once already and turned CI red on every open pull request.
-#
-# Keys are plain PATH PREFIXES matched against `git ls-files`, deliberately not globs:
-# reimplementing Vale's glob matcher would reproduce two known surprises, so `.vale.ini` is not
-# the source of truth either. A key ending in `/` matches everything under that directory; any
-# other key matches that path exactly.
-#
-# Values name the Vale Length rule that applies to those files, or `false` where none does.
-# Conformance rule 3 pairs each key with the `.vale.ini` section whose header spells it and
-# asserts the section turns that rule ON and every other Length rule OFF — asserting mere
-# presence would pass the exact config that once left ADRs checked by nothing.
+# The declared agent-facing set. Keys are path prefixes matched against `git ls-files`, not
+# globs; a trailing `/` matches a directory. Values name the Vale Length rule, or `false`.
 [tool.liulab.agent-docs]
 "AGENTS.md" = "LengthDoc"
 "CONTEXT.md" = "LengthDoc"
@@ -220,11 +169,8 @@ filterwarnings = ["error"]
 "docs/adr/" = "LengthAdr"
 "docs/research/" = false
 
-# Waivers. Keyed by RULE NAME, value the reason — per-rule, never per-file, because per-file
-# waivers grow into the second config this design just deleted. There is no expiry: every waiver
-# is printed on every run, green runs included, because an escape hatch that stops being visible
-# becomes permanent. `placeholder-rename` refuses to be waived; naming it here is itself a
-# failure. Length caps need no waiver, because the caps are dials in `styles/Lab/`.
+# Keyed by rule name, value the reason. Per-rule, never per-file; no expiry; printed on every
+# run. `placeholder-rename` refuses to be waived.
 #
 #     [tool.liulab.waived]
 #     repo-shape = "docs-only repo; the notebooks under src/ are examples, not a package"

--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -134,14 +134,13 @@ MARKED_BLOCKS = ((".github/workflows/ci.yml", "dogfood"), ("pyproject.toml", "do
 #: The task lines a repo with no package has no use for, matched whole.
 TASKS_A_PACKAGE_NEEDS = frozenset({'test = "pytest"', 'build = "python -m build"'})
 
-#: The command line's framework, and the three lines `pyproject.toml` declares it on: the wheel's
-#: own requirement, the comment introducing the conda mirror, and the mirror itself. A repo that
-#: declined a command line must not install the library only its command line imported, so all
-#: three go — and `drop_lock_dependency` takes the package out of `pixi.lock` with them.
+#: The command line's framework, and the two lines `pyproject.toml` declares it on: the wheel's
+#: own requirement and the conda mirror pixi installs from. A repo that declined a command line
+#: must not install the library only its command line imported, so both go — and
+#: `drop_lock_dependency` takes the package out of `pixi.lock` with them. Both anchors are the
+#: declarations themselves, never the prose near them, so rewording a comment cannot break this.
 CLI_DEPENDENCY = "typer"
-CLI_PROJECT_COMMENT = "# The command line's framework, and the only"
 CLI_PROJECT_DEPENDENCY = f'dependencies = ["{CLI_DEPENDENCY}>=0.12"]'
-CLI_PIXI_COMMENT = "# The one runtime dependency, mirrored from"
 CLI_PIXI_DEPENDENCY = f'{CLI_DEPENDENCY} = ">=0.12"'
 
 #: Committing needs an identity, and a fresh runner has none configured.
@@ -400,13 +399,10 @@ def drop_cli_dependency(text: str) -> str | None:
     Declared twice on purpose — the wheel's own requirement, and the conda mirror pixi installs
     from — so it has to be taken out twice. `[project] dependencies` is emptied rather than
     deleted: the key is where the first real dependency goes, and a wheel with no dependencies
-    says so explicitly. Each declaration's comment goes with it — a note explaining a dependency
-    that is not there any more is the same residue as the dependency.
+    says so explicitly.
     """
     anchors: tuple[Callable[[str], str | None], ...] = (
-        lambda t: drop_comment_block(t, CLI_PROJECT_COMMENT),
         lambda t: _replace(t, CLI_PROJECT_DEPENDENCY, "dependencies = []"),
-        lambda t: drop_comment_block(t, CLI_PIXI_COMMENT),
         lambda t: drop_lines(t, lambda line: line.rstrip() == CLI_PIXI_DEPENDENCY),
     )
     edited = text


### PR DESCRIPTION
`pyproject.toml` was 92 comment lines in 231, and `.vale.ini` 90 lines of which most were prose. Both are now trimmed to what a reader needs and nothing more.

**The rule applied:** no comment by default. One short line only where a value or its absence would otherwise read as a mistake — a deliberate omission (`no target-version`, no `fallback-version`), an exact pin (`pyright`, `vale`, `zensical`), or a non-obvious interaction (`default` taking `test` so pyright resolves pytest; `vale .` never an absolute path). The argument behind each rule already lives in an issue, a research note or a commit message, all of which are dated and searchable. A config file that re-argues them buries the settings it is meant to explain, and goes stale in silence.

| File | Before | After |
| --- | --- | --- |
| `pyproject.toml` | 231 lines, 92 comment | 177 lines, 38 comment |
| `.vale.ini` | 90 lines | 43 lines |

**Neither change alters behaviour, and both were checked rather than assumed.** `tomllib` parses `pyproject.toml` to identical values before and after. `vale ls-config` resolves `.vale.ini` to an identical config before and after.

## One real fix fell out of it

`init_repo.py` deleted the two comments above the `typer` declarations, and anchored that deletion on **the prose of those comments** — `CLI_PROJECT_COMMENT = "# The command line's framework, and the only"`. Rewording either comment would have broken `--no-cli`. That is the "declared in two places" hazard `skills/template-dev/SKILL.md` warns about, with a config comment as the second place.

Both anchors are now the declarations themselves, so a comment can be reworded freely. The remaining comment-text anchors all point at `mkdocs.yml` and `styles/`, which this PR does not touch.

The `# init-repo:begin dogfood` markers are machine-read, not commentary, and survive verbatim.

## Verified

- `pixi run check` green — 6 static steps, 8 conformance rules, 31 tests
- `pixi run dogfood` green on all three rungs. `not-published` is the `--no-cli` rung, so `drop_cli_dependency` ran with the comment anchors removed
- `vale ls-config` and `tomllib` equivalence as above