### PR TITLE
Drop the record pointer pyproject.toml no longer has

### DIFF
--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -111,7 +111,6 @@ TEMPLATE_RECORDS = (
 RECORD_POINTERS = (
     ("mkdocs.yml", f"# See {TEMPLATE_ADR}.\n", ""),
     (".github/workflows/docs.yml", f" See `{TEMPLATE_ADR}`.", ""),
-    ("pyproject.toml", f" (`{TEMPLATE_VALE_NOTE}`)", ""),
     ("styles/Lab/Readability.yml", f" See `{TEMPLATE_VALE_NOTE}`.", ""),
     (
         "styles/Lab/Jargon.yml",


### PR DESCRIPTION
#37 (comment trim) and #36 (stop shipping template records) crossed. The trimmed vale pin comment no longer cites `docs/research/vale-setup-2026-08-30.md`, so that entry in `RECORD_POINTERS` matched nothing and every `init-repo` run printed a `missed` line for it.

Nothing was broken — the outcome was already correct, and `init_repo.py` reports a missed anchor rather than writing back a file it did not understand. But a miss report that never means anything is how people learn to ignore the ones that do.

Rendered trees are unchanged, so [liulab-repo-demo](https://github.com/liuhlab/liulab-repo-demo) stays faithful and needs no re-render.

Verified: `pixi run check` green, `pixi run dogfood` green on all three rungs, and a fresh render prints no `missed` line.