### PR TITLE
Stop vale walking .pixi, which races the concurrent gate (#39)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,9 @@ typecheck = "pyright"
 test = "pytest"
 build = "python -m build"
 # `.`, never an absolute path: an absolute path matches no `.vale.ini` section and exits 0.
-vale = "vale ."
+# The globs stop vale walking trees it never lints — check.sh runs steps concurrently, and a
+# walk of .pixi/ races pytest writing __pycache__ there.
+vale = "vale --glob='!{.pixi,site,dist,build}/**' ."
 markdownlint = "markdownlint-cli2"
 conformance = "python scripts/conformance.py"
 # The static step list lives here and nowhere else; `check.sh` takes it as arguments.


### PR DESCRIPTION
Fixes #39. `vale .` walked `.pixi/` — thousands of files no `.vale.ini` section matches — while `check.sh`'s concurrent steps wrote `__pycache__` into the same tree. Vale stats a CPython temp `.pyc` after it has been renamed away and exits 2.

Intermittent, so it passed far more often than it failed. Dogfood caught it, which is the job dogfood exists for.

The invocation stays **relative**: an absolute path matches no section and exits 0, which is a silently disabled gate.

Verified: same 16 files linted; a planted jargon violation in a human-facing page still produces identical alerts; `pixi run check` green; `pixi run dogfood` green on all three rungs.