### PR TITLE
Publish the template's own documentation, and subtract it at init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,8 @@ sets one.
   files, and tags `v0.0.0`. It asks first about anything you have already edited.
 - The `dogfood` job, which renders this template for all three shapes on every pull
   request and proves each new repo passes its own checks and builds its own site.
+- `docs/template/index.md`, the page that says what the template ships and how to make a
+  repo from it, and `mkdocs.template.yml`, which inherits `mkdocs.yml` and names the site
+  after this repo while the shipped config keeps the placeholder. Both are template-only:
+  `init-repo` deletes them, takes `-f mkdocs.template.yml` off the two docs tasks, and cuts
+  the front page's pointer at the page.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ made from this template and left exactly as `init-repo` finished it. Its
 [site](https://liuhlab.github.io/liulab-repo-demo/) and its green checks are the same ones you
 get. Read it beside this repo to see what changes and what stays.
 
+The site has the longer version:
+[what the template ships, and what `init-repo` subtracts](https://liuhlab.github.io/liulab-repo-template/template/).
+
 ## Make a repo from it
 
 1. Press **Use this template** near the top of this page, then **Create a new repository**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,12 @@
 # liulab-newpkg
 
-One line: what this repo is for. `init-repo` rewrites this page.
-
+<!-- init-repo:begin template-docs -->
 This is the Liu Lab repo template with its placeholder package still in place. The package
-is called `liulab-newpkg` and imports as `newpkg`.
+is called `liulab-newpkg` and imports as `newpkg`. What the template ships, and how to make a
+repo from it, is on [The template](template/index.md).
+<!-- init-repo:end template-docs -->
+
+One line: what this repo is for. `init-repo` rewrites this page.
 
 ## Install it
 

--- a/docs/template/index.md
+++ b/docs/template/index.md
@@ -1,0 +1,65 @@
+# The Liu Lab repo template
+
+This repo is where a new Liu Lab repo starts. It is a complete, working repo wearing a
+placeholder name: it builds, it tests, it publishes this site, and every pull request on it
+passes the same rules it hands to the repos made from it. That is the point. The template is
+evidence, not a promise.
+
+The [demo repo](https://github.com/liuhlab/liulab-repo-demo) was made from this template and
+left exactly as `init-repo` finished it. Read it beside this one to see what changes and what
+stays.
+
+## What it ships
+
+| What | Detail |
+| --- | --- |
+| One toolchain | [pixi](https://pixi.sh), and nothing else. No pip, no conda, no uv. `pyproject.toml` is the one place dependencies, environments and tasks are declared. |
+| A working package | A small Python package with a command, tests that pass, and an API page built from its docstrings. |
+| One gate | `pixi run check` runs ruff, pyright, vale, markdownlint, a conformance check and pytest. It runs every step and prints all the failures at once. |
+| Writing rules | Vale checks them: word caps on the notes written for agents, plain language on the pages written for people. |
+| A docs site | This one. Built by zensical, published to GitHub Pages by a workflow. |
+| Skills for agents | Tracked links in `.claude/skills/` and `.agents/skills/` point at `skills/`, so an agent finds them the moment you clone. You install nothing. |
+| Notes for agents | `AGENTS.md`, `CONTEXT.md` and `docs/agents/` are written for a machine that has to act. They stay out of this menu and out of the search box. |
+
+## Making a repo from it
+
+1. Press **Use this template** on GitHub, then **Create a new repository**.
+2. Clone the new repo.
+3. Open a coding agent in it and say you just made a repo from the template.
+
+The `init-repo` skill takes it from there. It asks four things: the shape of the repo, the
+module name, whether you want a command, and one line on what the repo is for. The shape is a
+ladder — a package the lab publishes, a package it keeps to itself, or no package at all.
+
+A script then does every mechanical step. It renames the placeholder package, drops the parts
+you said you do not need, rewrites the README, commits, and tags a first version. If you would
+rather skip the agent, run it yourself:
+
+```bash
+python scripts/init_repo.py --help
+```
+
+It is careful about your work in a way worth knowing. Renaming always runs. A deletion or an
+overwrite runs unasked only while the file is still byte-identical to the first commit, which
+is what a repo made from the button has. Anything you already edited, it asks about, and the
+default answer is keep. `--plan` shows you the whole survey and changes nothing.
+
+## What init-repo subtracts
+
+A new repo should not inherit the machinery that made it. So the script deletes:
+
+- both agent skills — `init-repo` and `template-dev` — and their tracked links
+- `scripts/init_repo.py`, `scripts/dogfood.py`, and the CI job that renders this template
+- this page, and the config file that names the site after the template
+- the template's own decision record and research notes, plus every sentence in a surviving
+  file that pointed at one of them
+- the entries in `CHANGELOG.md`, which are this template's history and not the new repo's.
+  The file itself always ships.
+
+Then the shape decides the rest. A repo that does not publish loses the release workflow. A
+repo with no package also loses `src/` and `tests/`.
+
+Nothing above is a claim you have to take on faith. Every pull request here renders the
+template three times, once per shape, and hands each result to its own gate and its own docs
+build. A file that should have gone, or a link left pointing at one, fails the build in this
+repo rather than in yours.

--- a/mkdocs.template.yml
+++ b/mkdocs.template.yml
@@ -1,0 +1,26 @@
+# TEMPLATE-ONLY: the config that builds THIS repo's site, as itself.
+#
+# `scripts/init_repo.py` deletes this file and takes `-f mkdocs.template.yml` off the two docs
+# tasks in `pyproject.toml` with it, so a derived repo builds from `mkdocs.yml` alone.
+#
+# It exists because the identity keys in `mkdocs.yml` ship carrying the PLACEHOLDER on purpose:
+# they are the only check that a derived repo's published site points at the repo itself, and
+# writing the template's own name in there would quietly remove it. So the template overrides
+# them here instead — `INHERIT` reads `mkdocs.yml` whole, the keys below win over it, and the
+# placeholder stays where the rename check can still see it.
+#
+# `nav:` APPENDS to the nav in `mkdocs.yml` rather than replacing it, because an inherited list
+# is joined rather than overwritten. So this file names only the page a derived repo never gets.
+#
+# `INHERIT` is a documented mkdocs feature that zensical implements and its own source calls a
+# bandaid, so treat it as alpha (see `docs/adr/0001-docs-site-on-zensical.md`). If it goes, this
+# file becomes a full copy of `mkdocs.yml`, and nothing a derived repo keeps has to change.
+INHERIT: mkdocs.yml
+site_name: liulab-repo-template
+site_url: https://liuhlab.github.io/liulab-repo-template/
+repo_url: https://github.com/liuhlab/liulab-repo-template
+repo_name: liuhlab/liulab-repo-template
+site_description: "The starting point for a new Liu Lab repo: one toolchain, one gate, and
+  a script that customises the copy."
+nav:
+  - The template: template/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,13 @@ mkdocstrings-python = ">=2.0.7,<3"
 
 # On the feature, so these resolve in the `docs` environment with no `-e` flag.
 # `serve` ignores `--strict` and says so, hence its absence.
+#
+# `-f mkdocs.template.yml` is TEMPLATE-ONLY. That file inherits `mkdocs.yml` and overrides the
+# identity keys, so this repo's site is named for itself while the shipped config keeps the
+# placeholder. `init-repo` deletes the file and takes the flag off both lines below.
 [tool.pixi.feature.docs.tasks]
-docs = "zensical serve"
-docs-build = "zensical build --clean --strict"
+docs = "zensical serve -f mkdocs.template.yml"
+docs-build = "zensical build -f mkdocs.template.yml --clean --strict"
 
 # `default` takes `test` so pyright can resolve pytest, and not `docs`, which exists so that
 # exactly one CI job installs it.

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -55,15 +55,19 @@ PLACEHOLDER = "new" + "pkg"
 #: them, each edited by a different anchor in `scripts/init_repo.py`.
 CLI_DEPENDENCY = "typer"
 
-#: The template's own records — how it chose its docs site, and the evidence behind the rules it
-#: ships. Spelled out here rather than imported from `scripts/init_repo.py`, for the reason the
-#: two constants above are: an assertion that reads its expectation out of the thing it is
-#: checking cannot tell a deletion that ran from a list that quietly lost an entry.
-TEMPLATE_RECORDS = (
+#: What this repo says about ITSELF: its own records — how it chose its docs site, and the
+#: evidence behind the rules it ships — and the two files that publish it as the template, the
+#: page describing it and the config that names the site after it. Spelled out here rather than
+#: imported from `scripts/init_repo.py`, for the reason the two constants above are: an assertion
+#: that reads its expectation out of the thing it is checking cannot tell a deletion that ran
+#: from a list that quietly lost an entry.
+TEMPLATE_ARTIFACTS = (
     "docs/adr/0001-docs-site-on-zensical.md",
     "docs/research/github-template-mechanics-2026-08-30.md",
     "docs/research/vale-setup-2026-08-30.md",
     "docs/research/zensical-viability-2026-08-30.md",
+    "docs/template/index.md",
+    "mkdocs.template.yml",
 )
 
 #: The `PIXI_*` variables a parent `pixi run` exports. They name the TEMPLATE's manifest, and a
@@ -202,19 +206,20 @@ def check_declined_cli(rung: Rung, stage: Path) -> list[str]:
     ]
 
 
-def check_template_records(stage: Path) -> list[str]:
-    """Grep a rendered repo for the template's own records, as a path and as a citation.
+def check_template_artifacts(stage: Path) -> list[str]:
+    """Grep a rendered repo for what the template says about itself, as a path and a citation.
 
-    None of the four is about the repo that inherited it, and the rendered repo's own gate is
-    happy either way — a stale ADR passes every rule the template propagates. Citations are
-    checked with the paths because a comment pointing at a document that is not there is the
-    same residue as the document, spread over more files.
+    None of it is about the repo that inherited it, and the rendered repo's own gate is happy
+    either way — a stale ADR passes every rule the template propagates. Citations are checked
+    with the paths because a comment pointing at a document that is not there is the same residue
+    as the document, spread over more files, and because the citation is the only thing that
+    catches a docs task still built with `-f mkdocs.template.yml`.
     """
     tracked = tracked_paths(stage)
     problems = [
-        f"{record} is the template's own record and is still tracked"
-        for record in TEMPLATE_RECORDS
-        if record in tracked
+        f"{artifact} is the template's own and is still tracked"
+        for artifact in TEMPLATE_ARTIFACTS
+        if artifact in tracked
     ]
     for rel in tracked:
         path = stage / rel
@@ -222,9 +227,9 @@ def check_template_records(stage: Path) -> list[str]:
             continue
         body = path.read_bytes()
         problems += [
-            f"{rel} still points at {record}, which this repo does not have"
-            for record in TEMPLATE_RECORDS
-            if record.encode() in body
+            f"{rel} still points at {artifact}, which this repo does not have"
+            for artifact in TEMPLATE_ARTIFACTS
+            if artifact.encode() in body
         ]
     return problems
 
@@ -304,7 +309,7 @@ def render(rung: Rung, parent: Path) -> None:
         check_placeholder(stage)
         + check_shape(rung, stage)
         + check_declined_cli(rung, stage)
-        + check_template_records(stage)
+        + check_template_artifacts(stage)
         + check_changelog(stage)
     )
     if problems:

--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -23,8 +23,10 @@ Actions come in two kinds, and only one of them is dangerous:
 
 Exempt from that check, deleted unconditionally and tolerated when absent: the two skill
 directories, their four symlinks, the `dogfood` job and its task, `scripts/dogfood.py`, this
-file, and the template's own records — the ADR and the three research notes that say how the
-template was built. Their removal is the entire point, so nothing about them is negotiable.
+file, the two files that publish this repo as the template — `docs/template/index.md` and the
+`mkdocs.template.yml` that names the site after it — and the template's own records, the ADR and
+the three research notes that say how the template was built. Their removal is the entire point,
+so nothing about them is negotiable.
 `CHANGELOG.md` is the one record handled the other way: the file always ships, and emptying it
 of the template's entries is guarded, so a late init never discards what someone wrote.
 
@@ -81,6 +83,10 @@ TEMPLATE_ONLY = (
     ".claude/skills/template-dev",
     ".agents/skills/init-repo",
     ".agents/skills/template-dev",
+    # The template's own site: the page about the template, and the config that names the site
+    # after it. `mkdocs.yml` is the config every repo keeps and is not here.
+    "docs/template/index.md",
+    "mkdocs.template.yml",
     "scripts/dogfood.py",
     "scripts/init_repo.py",
 )
@@ -125,10 +131,15 @@ RECORD_POINTERS = (
 #: format to write in, and keeps this file from holding a second copy of it to drift from.
 CHANGELOG_UNRELEASED = "## [Unreleased]"
 
-#: Files carrying an `init-repo:begin dogfood` / `init-repo:end dogfood` pair. The dogfood job
-#: cannot be deleted by path — it is one job inside a workflow every repo keeps — so it ships as
-#: a delimited trailing block and removing it stays mechanical instead of becoming YAML surgery.
-MARKED_BLOCKS = ((".github/workflows/ci.yml", "dogfood"), ("pyproject.toml", "dogfood"))
+#: Files carrying an `init-repo:begin <name>` / `init-repo:end <name>` pair. Template-only text
+#: inside a file every repo keeps cannot be deleted by path — the dogfood job is one job in a
+#: workflow, the front page's pointer at `docs/template/` is one paragraph of a page — so each
+#: ships delimited, and removing it stays mechanical instead of becoming YAML or prose surgery.
+MARKED_BLOCKS = (
+    (".github/workflows/ci.yml", "dogfood"),
+    ("pyproject.toml", "dogfood"),
+    ("docs/index.md", "template-docs"),
+)
 
 #: The task lines a repo with no package has no use for, matched whole.
 TASKS_A_PACKAGE_NEEDS = frozenset({'test = "pytest"', 'build = "python -m build"'})
@@ -175,20 +186,6 @@ def drop_lines(text: str, accepts: Callable[[str], bool]) -> str | None:
     lines = _lines(text)
     kept = [line for line in lines if not accepts(line)]
     return "".join(kept) if len(kept) != len(lines) else None
-
-
-def drop_paragraph(text: str, prefix: str) -> str | None:
-    """Remove the paragraph starting at the first line with this prefix, and the blank after it."""
-    lines = _lines(text)
-    start = _find(lines, lambda line: line.startswith(prefix))
-    if start is None:
-        return None
-    end = start
-    while end < len(lines) and lines[end].strip():
-        end += 1
-    while end < len(lines) and not lines[end].strip():
-        end += 1
-    return _cut(lines, start, end)
 
 
 def drop_example(text: str, prefix: str) -> str | None:
@@ -799,9 +796,19 @@ class Init:
             lambda text: drop_markdown_section(text, "### Placeholder package"),
         )
         self.edit(
-            "docs/index.md",
-            "the paragraph about the template",
-            lambda text: drop_paragraph(text, "This is the Liu Lab repo template"),
+            "pyproject.toml",
+            "the note about the template's own site config",
+            lambda text: drop_comment_block(text, "# `-f mkdocs.template.yml` is TEMPLATE-ONLY"),
+        )
+        self.edit(
+            "pyproject.toml",
+            "the template's site config, in both docs tasks",
+            lambda text: _replace(
+                text,
+                'docs = "zensical serve -f mkdocs.template.yml"\n'
+                'docs-build = "zensical build -f mkdocs.template.yml --clean --strict"',
+                'docs = "zensical serve"\ndocs-build = "zensical build --clean --strict"',
+            ),
         )
         for rel, old, new in RECORD_POINTERS:
             self.edit(

--- a/skills/template-dev/SKILL.md
+++ b/skills/template-dev/SKILL.md
@@ -64,6 +64,12 @@ Deletion is **by exact path**, never by directory: a repo initialized late may h
 written `docs/adr/0002-*.md` already, and `docs/adr/` is allowed to disappear when its
 last file does. No `.gitkeep` — `/domain-modeling` makes the directory when it needs one.
 
+The site is two configs. `mkdocs.yml` ships the placeholder identity, as above;
+`mkdocs.template.yml` inherits it, overrides the identity, and adds `docs/template/index.md`
+— the page about the template — to the nav. Both files go at init, with the `-f` flag on the
+two docs tasks and the marked block on `docs/index.md`. Prose about the template belongs on
+that page, never on one a derived repo keeps.
+
 `CHANGELOG.md` is the exception that proves the shape. The file always ships, because a
 repo that publishes needs one, but its entries are this template's history, so they are
 emptied out — guarded by the untouched check, so a late init never cuts real entries. Add


### PR DESCRIPTION
The published site was the placeholder demo and nothing else — a page titled `liulab-newpkg` explaining how to install a package that does not exist. A visitor to the template's docs learned nothing about the template. This puts the tutorial on the site and makes sure it travels nowhere.

## What lands

- **`docs/template/index.md`** — what the template ships, how to make a repo from it (the four questions, the three shapes, the byte-identical safety rule), and what `init-repo` subtracts. Human-facing, so Vale's jargon and grade-11 rules apply to it; a planted violation fires three alerts.
- **`mkdocs.template.yml`** — `INHERIT: mkdocs.yml`, then the identity keys and one nav entry. Inherited lists join rather than replace, so the nav comes out Home / API reference / The template with the shipped one not repeated. Both docs tasks build through it.

`mkdocs.yml` is untouched. Its identity keys stay on the placeholder, which is the whole reason for the overlay: they are the only check that a derived repo's published site points at itself, and writing this template's name in there would quietly remove it.

## How it leaves

Three idioms already in the tree, none of them new:

| Piece | Mechanism |
| --- | --- |
| `docs/template/index.md`, `mkdocs.template.yml` | `TEMPLATE_ONLY`, deleted by exact path, emptied dir pruned |
| The front page's pointer at the page | an `init-repo:begin/end template-docs` block |
| `-f mkdocs.template.yml` on the two docs tasks, and its comment | two anchored edits in `prune_shared` |

`dogfood.py` greps each rendered repo for both paths **as a path and as a citation** — the citation half is the only thing that catches a docs task still built with the overlay. `drop_paragraph` lost its last caller and went with it.

## Proof

All three rungs render green. The kept render of the `published` rung:

```
docs/            agents/  api.md  index.md          ← no template/
pyproject.toml   docs = "zensical serve"
                 docs-build = "zensical build --clean --strict"
mkdocs.template.yml   No such file
git grep "mkdocs.template|docs/template|template-docs" → none
```

Front page and task lines byte-identical to what the template shipped before this change.

## Known soft spot

`INHERIT` is a documented mkdocs feature, but zensical's own source calls it "a bandaid" it plans to replace. If it goes, `mkdocs.template.yml` becomes a full copy of `mkdocs.yml` and nothing a derived repo keeps has to change. That is written into the file's header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaYjMqzMxEEVRtE3R5aEH2