### PR TITLE
Four conformance rules, a gate runner that surfaces failures, doctests, and what the docs build misses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@
 #
 # Every step invokes `pixi run <task>` and never a command line. The step list lives in
 # `pyproject.toml` — `check-static` names it once — so this file and a laptop cannot drift:
-# adding a step is one more word there and nothing here.
+# adding a step is one more word there and nothing here. This paragraph is the advice and
+# conformance rule `workflow-step-tasks` is the enforcement, over every workflow in the
+# repo and not only this one; they say one thing, so they change together.
 #
 # Not shipped, deliberately: a `claude.yml`, because on a public repo anyone who can
 # comment could spend the API budget; container and benchmark workflows, because nothing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,10 @@ jobs:
           locked: true
       # `docs-build` is a task on the `docs` FEATURE, so pixi finds it in the one
       # environment that has zensical and no `-e` flag is needed. The task carries
-      # `--strict`, so a broken link or a bad reference fails here. This job builds the
+      # `--strict`, so a dead link or a bad reference fails here — but not every kind of
+      # broken link, and not a `nav:` entry naming a missing file. The comment above
+      # `validation:` in `mkdocs.yml` lists what this job catches and what it does not, so
+      # a green run here is not a claim the site has no dead ends. This job builds the
       # site and stops; publishing it is `docs.yml`, on `main`.
       - run: pixi run docs-build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,13 @@
 name: release
 
 on:
-  # NEVER `push: tags:`. `init-repo` pushes `v0.0.0` on a repo's first day so the version
-  # does not read as if a release already happened, and a tag trigger would fire a PyPI
+  # NEVER a trigger that a tag push can fire — `push: tags:`, a `push:` with no branch
+  # filter, or `create`. `init-repo` pushes `v0.0.0` on a repo's first day so the version
+  # does not read as if a release already happened, and any of those would fire a PyPI
   # publish right then, from a repo nobody has finished naming. Publishing a GitHub Release
-  # is a deliberate act by a person, so that is the trigger.
+  # is a deliberate act by a person, so that is the trigger. This paragraph is the advice
+  # and conformance rule `release-trigger` is the enforcement; they say one thing, so they
+  # change together.
   release:
     types: [published]
   # For a release whose publish failed on something outside the code — a missing trusted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ wrong. Distribution name **`liulab-newpkg`**, import name **`newpkg`**.
 
 - **pixi** is the only supported toolchain. Never bare pip, uv, or conda. `pyproject.toml`
   is the single source of truth for dependencies, environments, and tasks.
-- **Python 3.13**, declared in exactly two places: `requires-python` and the pixi pin.
+- **Python 3.13**, declared by `requires-python` and the pixi pin. Write it anywhere else — a
+  ruff target, a pyright version — and `conformance` holds that copy to the floor.
 - **hatchling + hatch-vcs**. The version comes from the newest git tag, CalVer
   `vYYYY.M.PATCH`. Never hand-edit a version.
 - Platforms: `osx-arm64` and `linux-64`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ sets one.
   files, and tags `v0.0.0`. It asks first about anything you have already edited.
 - The `dogfood` job, which renders this template for all three shapes on every pull
   request and proves each new repo passes its own checks and builds its own site.
+- A conformance rule for the Python version. The pixi pin has to meet the
+  `requires-python` floor, and any tool that writes a language level down has to write that
+  floor. It checks that the declarations agree, and does not count them, so a repo that
+  supports a range of Python versions still passes.
 - `docs/template/index.md`, the page that says what the template ships and how to make a
   repo from it, and `mkdocs.template.yml`, which inherits `mkdocs.yml` and names the site
   after this repo while the shipped config keeps the placeholder. Both are template-only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ sets one.
   files, and tags `v0.0.0`. It asks first about anything you have already edited.
 - The `dogfood` job, which renders this template for all three shapes on every pull
   request and proves each new repo passes its own checks and builds its own site.
+- A conformance rule that fails a publishing workflow a tag push can trigger, and the
+  workflow reader it is built on: the check now parses every workflow file, its triggers
+  and its steps, instead of only reading text.
 - `docs/template/index.md`, the page that says what the template ships and how to make a
   repo from it, and `mkdocs.template.yml`, which inherits `mkdocs.yml` and names the site
   after this repo while the shipped config keeps the placeholder. Both are template-only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,6 @@ sets one.
   after this repo while the shipped config keeps the placeholder. Both are template-only:
   `init-repo` deletes them, takes `-f mkdocs.template.yml` off the two docs tasks, and cuts
   the front page's pointer at the page.
+- Docstring examples as tests. `pytest` collects the doctests in `src/` alongside `tests/`,
+  so an example that has drifted from the code it documents fails the gate. `docs/api.md`
+  says how to mark a line that cannot run offline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ sets one.
 
 - The placeholder package, the pixi workspace, and the three environments.
 - `scripts/check.sh`, the gate runner behind `pixi run check`: it runs every static step
-  concurrently and reports all failures, not just the first.
+  concurrently and reports all failures, not just the first. A step that passes is shown
+  as a short tail and one that fails in full, the summary says how long each step took,
+  and a run stopped with Ctrl-C takes its steps down with it.
 - The writing gate: `vale` and `markdownlint` as steps of `check-static`, with the four
   `Lab` rules tracked in `styles/Lab/`.
 - The three workflows: `ci.yml` runs the gate on every pull request, `docs.yml` publishes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ sets one.
 - A conformance rule that fails a publishing workflow a tag push can trigger, and the
   workflow reader it is built on: the check now parses every workflow file, its triggers
   and its steps, instead of only reading text.
+- A conformance rule that fails a workflow step running a command of its own instead of
+  `pixi run <task>`, or naming a task nothing declares. The step list stays in one place,
+  so what CI runs and what your laptop runs cannot quietly stop being the same thing.
 - `docs/template/index.md`, the page that says what the template ships and how to make a
   repo from it, and `mkdocs.template.yml`, which inherits `mkdocs.yml` and names the site
   after this repo while the shipped config keeps the placeholder. Both are template-only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@ sets one.
   after this repo while the shipped config keeps the placeholder. Both are template-only:
   `init-repo` deletes them, takes `-f mkdocs.template.yml` off the two docs tasks, and cuts
   the front page's pointer at the page.
+- A `validation:` block in `mkdocs.yml` turning on the five link checks the site builder
+  ships switched off, and a comment beside it listing, from measurement, which broken links
+  a strict build catches and which three it lets through. A `nav:` entry naming a file that
+  is not there is one of the three, and no setting catches it.

--- a/docs/adr/0001-docs-site-on-zensical.md
+++ b/docs/adr/0001-docs-site-on-zensical.md
@@ -8,7 +8,7 @@ search:
 The site is built by `zensical`, pinned `==0.0.57`, not by mkdocs plus mkdocs-material.
 zensical reads the same `mkdocs.yml`, runs the same Python-Markdown extensions in-process,
 and renders mkdocstrings, so one repo can move back to mkdocs by changing two lines in
-`pyproject.toml`.
+`pyproject.toml` and dropping the zensical-only validation keys from `mkdocs.yml`.
 
 ## Why this is surprising
 
@@ -29,9 +29,12 @@ Three gaps, each with a named workaround:
   or not it is listed anywhere. Agent-facing pages therefore carry `search: exclude: true`
   front matter, and `mkdocs.yml` carries an explicit `nav:`. Front matter does nothing
   about the navbar; `nav:` does nothing about search. Both, always.
-- **A `nav:` entry naming a missing file no longer fails `--strict`.** `mkdocs build
-  --strict` caught that. Dead internal links and unresolved mkdocstrings references still
-  fail, so `--strict` is still worth passing.
+- **`--strict` validates links, not the `nav:`.** A nav entry naming a missing file failed
+  a strict mkdocs build and passes this one, and no setting turns that back on. Dead links
+  and dead anchors still fail, so `--strict` is worth passing. The measured list of what it
+  catches and misses is a comment in `mkdocs.yml`, beside the `nav:` a maintainer edits and
+  the settings it turns on — this record is deleted from a repo made from the template, and
+  the gap is not.
 
 The research note expected one residue — excluded pages still listed in `sitemap.xml`. With
 an explicit `nav:` that does not happen: zensical builds the sitemap from the nav, so the

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,6 +3,22 @@
 Built from the docstrings in `src/newpkg/`, so this page and the code cannot drift apart.
 Write the docstring; this page follows.
 
+## The examples are tests
+
+Give every public object an `Examples` block. `pixi run check` runs those blocks, so an
+example that no longer matches its code fails the tests.
+
+Keep an example cheap, offline and deterministic. It has to give the same answer on any
+machine, with no network. A line that cannot do that needs `# doctest: +SKIP` at the end of
+that line.
+
+Two things about that marker are easy to get backwards:
+
+- It covers only the line it sits on. It does not carry to the line below. In a block that
+  mixes lines that run with lines that cannot, each line that cannot run needs its own.
+- A trailing comment written as plain prose looks just like a marker and is not one. Only
+  the `# doctest:` form is read as one.
+
 ## newpkg
 
 ::: newpkg.core.greet

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,11 +18,44 @@ site_description: "One line: what this repo is for. `init-repo` rewrites this."
 # `search: exclude: true` front matter on those pages is for. Neither mechanism
 # substitutes for the other, and `exclude_docs:` is silently ignored, so both are needed.
 #
-# Add a human-facing page here when you write one. Never add a page under docs/adr/,
-# docs/agents/ or docs/research/: conformance rule 2 fails the build if you do.
+# Add a human-facing page here when you write one, and CHECK THE FILE IS THERE — a nav
+# entry naming a missing file builds green and publishes a menu item that 404s. Never add a
+# page under docs/adr/, docs/agents/ or docs/research/: conformance rule 2 fails the build
+# if you do.
 nav:
   - Home: index.md
   - API reference: api.md
+
+# What `--strict` catches. Every row was built against the pinned zensical and watched, not
+# taken from what a strict mkdocs build used to do:
+#
+#   caught  link to a page that is not there   [text](gone.md)
+#   caught  dead anchor                        [text](api.md#gone)
+#   caught  unresolved mkdocstrings reference  [`pkg.Thing`][pkg.Thing]
+#   MISSED  nav: entry naming a missing file     - Gone: gone.md
+#   MISSED  absolute link                      [text](/gone/)
+#   MISSED  link with no `.md` extension       [text](api)
+#
+# Nothing below fixes the three MISSED rows and no setting does: zensical validates links
+# and not the nav, and it drops mkdocs' `absolute_links:` and `unrecognized_links:` keys in
+# silence, so writing them in would look like a check and be none. Read those three rows as
+# work for a human. Row three needs the mkdocstrings plugin, so a repo without one is down
+# to two.
+#
+# `not_found:` and `anchors:` are zensical's defaults, spelled out because they are the two
+# keys mkdocs also understands. The five under them are zensical's own and mkdocs rejects
+# them, so a move back to mkdocs deletes this block as well as the pixi lines.
+# `unresolved_references:` is left off on purpose: it reads any bracketed word in prose,
+# `[draft]`, as a broken link reference and fails the build on it.
+validation:
+  links:
+    not_found: warn
+    anchors: warn
+  unresolved_footnotes: true
+  unused_definitions: true
+  unused_footnotes: true
+  shadowed_definitions: true
+  shadowed_footnotes: true
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,8 +157,10 @@ reportMissingTypeStubs = "none"
 # ============================== pytest ==============================
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
-addopts = ["-ra", "--strict-markers", "--strict-config"]
+# `src` is collected for its docstring examples alone: `--doctest-modules` runs them, so an
+# example that has drifted from the code it documents fails.
+testpaths = ["tests", "src"]
+addopts = ["-ra", "--strict-markers", "--strict-config", "--doctest-modules"]
 xfail_strict = true
 filterwarnings = ["error"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ platforms = ["osx-arm64", "linux-64"]
 [tool.pixi.pypi-dependencies]
 liulab-newpkg = { path = ".", editable = true }
 
-# Python is pinned here and nowhere else; `requires-python` is its only other mention.
+# The interpreter. `requires-python` is the floor, and conformance holds every other Python
+# version this repo declares to it.
 # Runtime dependencies are mirrored from `[project] dependencies` so pixi takes them from
 # conda-forge rather than PyPI.
 [tool.pixi.dependencies]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,8 +5,13 @@
 # Each argument names a task in [tool.pixi.tasks]. The steps all start at once and
 # each one's output is captured to its own file, because interleaved concurrent
 # output is unreadable. Nothing is printed until every step has finished; then each
-# step gets a labelled block, in the order it was named, followed by a summary.
-# The exit status is non-zero if any step failed.
+# step gets a labelled block, in the order it was named, followed by a summary that
+# carries each step's verdict and how long it took. The exit status is non-zero if
+# any step failed.
+#
+# A passing step prints only the last few lines it wrote; a failing step prints
+# everything. A red run is read to find the failure, and the full output of every
+# green step is thousands of lines of nothing standing between the reader and it.
 #
 # The step list lives in the `check-static` task in pyproject.toml and nowhere else,
 # so adding a step is one more word in one place and the local gate cannot drift
@@ -16,10 +21,19 @@
 # first failing step, and telling you everything that is wrong in a single run is
 # the entire point of this file.
 #
+# `set -m` gives every step its own process group, so one kill on the negated pid
+# reaches past `pixi` to the test workers underneath. It also means Ctrl-C never
+# reaches a step: a terminal signals its foreground group, and the steps are not in
+# it. So interrupt and terminate are turned into an ordinary exit, which is what
+# lets the EXIT trap run, and that trap kills the groups BEFORE removing the capture
+# directory. Killing first is the whole point of the ordering — a step still writing
+# into a directory that has been deleted is the race it closes. An abandoned gate
+# used to keep every worker it started, so the next run competed with the last one.
+#
 # Portable to bash 3.2, which is what macOS ships: no `wait -n`, no associative
 # arrays, nothing beyond coreutils.
 
-set -uo pipefail
+set -muo pipefail
 
 if [ "$#" -eq 0 ]; then
     printf 'usage: %s <pixi-task>...\n' "$0" >&2
@@ -29,16 +43,46 @@ fi
 steps=("$@")
 count=$#
 
+# How much of a passing step is worth reading.
+tail_lines=3
+
 capture_dir=$(mktemp -d "${TMPDIR:-/tmp}/liulab-check.XXXXXX") || exit 2
-trap 'rm -rf "$capture_dir"' EXIT
+
+# Kill, then delete, in that order and never one without the other. Each surviving
+# job leads its own process group, so the negated pid takes its children with it.
+cleanup() {
+    # Job control has done its work by now; leaving it on only makes the shell print
+    # a "Terminated" notice, quoting the whole step, for each job killed below.
+    set +m
+    for pgid in $(jobs -p); do
+        kill -- "-$pgid" 2>/dev/null
+    done
+    wait 2>/dev/null
+    rm -rf "$capture_dir"
+}
+trap cleanup EXIT
+# A signal would otherwise end this shell without running the EXIT trap, and every
+# step would outlive the gate that started it.
+trap 'printf "\ninterrupted, stopping every step\n" >&2; exit 130' INT
+trap 'printf "\nterminated, stopping every step\n" >&2; exit 143' TERM
 
 rule="--------------------------------------------------------------------"
 
-# Start every step.
+# Start every step. The subshell is what makes it a job, and so a process group; it
+# also times the step, which this shell cannot do, because it collects statuses in
+# launch order rather than in the order the steps finish. Steps get no stdin: one
+# that asks a question would otherwise be stopped by its own terminal and hang the
+# gate until CI times out.
 pids=()
 i=0
 while [ "$i" -lt "$count" ]; do
-    pixi run "${steps[$i]}" >"$capture_dir/$i" 2>&1 &
+    (
+        started=$SECONDS
+        pixi run "${steps[$i]}" </dev/null >"$capture_dir/$i.log" 2>&1
+        status=$?
+        printf '%s' "$((SECONDS - started))" >"$capture_dir/$i.time"
+        exit "$status"
+    ) &
     pids[$i]=$!
     i=$((i + 1))
 done
@@ -46,14 +90,17 @@ done
 # Collect every status. Without `wait -n` this waits in launch order, which costs
 # nothing: the steps are already running, and no failure short-circuits the loop.
 statuses=()
+elapsed=()
 i=0
 while [ "$i" -lt "$count" ]; do
     wait "${pids[$i]}"
     statuses[$i]=$?
+    elapsed[$i]=$(cat "$capture_dir/$i.time" 2>/dev/null)
+    [ -n "${elapsed[$i]}" ] || elapsed[$i]="?"
     i=$((i + 1))
 done
 
-# One labelled block per step, output in full, pass or fail.
+# One labelled block per step: the tail of a passing one, all of a failing one.
 failed=0
 i=0
 while [ "$i" -lt "$count" ]; do
@@ -64,7 +111,16 @@ while [ "$i" -lt "$count" ]; do
         failed=$((failed + 1))
     fi
     printf '\n%s\n%s  %s\n%s\n' "$rule" "$verdict" "${steps[$i]}" "$rule"
-    cat "$capture_dir/$i"
+    if [ "$verdict" = "FAIL" ]; then
+        cat "$capture_dir/$i.log"
+    else
+        lines=$(wc -l <"$capture_dir/$i.log")
+        if [ "$lines" -gt "$tail_lines" ]; then
+            printf '[%s earlier lines hidden; a failing step prints in full]\n' \
+                "$((lines - tail_lines))"
+        fi
+        tail -n "$tail_lines" "$capture_dir/$i.log"
+    fi
     i=$((i + 1))
 done
 
@@ -73,17 +129,18 @@ printf '\n%s\nsummary\n%s\n' "$rule" "$rule"
 i=0
 while [ "$i" -lt "$count" ]; do
     if [ "${statuses[$i]}" -eq 0 ]; then
-        printf '  pass  %s\n' "${steps[$i]}"
+        printf '  pass  %s (%ss)\n' "${steps[$i]}" "${elapsed[$i]}"
     else
-        printf '  FAIL  %s (exit %s)\n' "${steps[$i]}" "${statuses[$i]}"
+        printf '  FAIL  %s (exit %s, %ss)\n' \
+            "${steps[$i]}" "${statuses[$i]}" "${elapsed[$i]}"
     fi
     i=$((i + 1))
 done
 
 if [ "$failed" -gt 0 ]; then
-    printf '\n%s of %s steps failed. Every failure is above; read to the bottom.\n' \
-        "$failed" "$count" >&2
+    printf '\n%s of %s steps failed in %ss. Every failure is above; read to the bottom.\n' \
+        "$failed" "$count" "$SECONDS" >&2
     exit 1
 fi
 
-printf '\nAll %s steps passed.\n' "$count"
+printf '\nAll %s steps passed in %ss.\n' "$count" "$SECONDS"

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -5,7 +5,7 @@
     python scripts/conformance.py [--root PATH]
 
 It states the RULE, not the file contents — a pull model, so a repo that legitimately diverges
-stays green while the shared conventions stay checked. Ten rules: eight fail, two only warn.
+stays green while the shared conventions stay checked. Eleven rules: nine fail, two only warn.
 
 Three things it does on purpose:
 
@@ -55,7 +55,7 @@ import yaml
 #: neither happens.
 PLACEHOLDER = "new" + "pkg"
 
-#: Rule 1 and warning 9 are both gated on this directory, and it is the only discriminator either
+#: Rule 1 and warning 10 are both gated on this directory, and it is the only discriminator either
 #: needs. While it is here, `init-repo` has not run: the placeholder is still the repo's own name,
 #: and the auto-discovered skill is itself the nag. Once it is gone the repo claims to be its own,
 #: and both rules start checking.
@@ -67,6 +67,18 @@ UNWAIVABLE = "placeholder-rename"
 #: Where `mkdocs.yml` puts the site source when it does not say. Rule 2 is scoped to the pages the
 #: site publishes, so it reads this rather than assuming.
 DEFAULT_DOCS_DIR = "docs"
+
+#: Where GitHub reads workflows, and the two file endings it accepts. Nothing below this
+#: directory is a workflow, and nothing above it is read.
+WORKFLOW_DIR = ".github/workflows/"
+WORKFLOW_SUFFIXES = (".yml", ".yaml")
+
+#: The publishing workflow, named by PATH rather than sniffed out of its contents. That is a
+#: deliberate choice and not a shortcut: a package index binds its trusted publisher to an owner,
+#: a repository and a WORKFLOW FILENAME, so this name is external configuration — rename the file
+#: and the repo cannot publish at all. `init-repo` also deletes it by this exact path. Rules 8 and
+#: 9 both read it, so the name is written here once and nowhere else.
+RELEASE_WORKFLOW = f"{WORKFLOW_DIR}release.yml"
 
 #: Vale's spelling of on and off. Both forms appear in the wild; the gate accepts either.
 VALE_ON = {"YES", "TRUE", "ON"}
@@ -126,6 +138,108 @@ class Result:
 
     problems: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Step:
+    """One step of one job, flattened out of the workflow it came from.
+
+    Attributes
+    ----------
+    workflow
+        Repo-relative path of the file this step was written in.
+    job
+        The job key it sits under, so a report can say where without a second lookup.
+    index
+        Its position in that job's `steps:` list, counting from zero. A step need not have a
+        `name:`, and this is the only thing that always identifies one.
+    name, uses, run
+        The three keys a rule asks about, each ``None`` when the step does not set it. A step
+        has `uses` or `run` and never both.
+    """
+
+    workflow: str
+    job: str
+    index: int
+    name: str | None
+    uses: str | None
+    run: str | None
+
+
+@dataclass(frozen=True)
+class Workflow:
+    """One workflow definition, parsed once for every rule that reads workflows.
+
+    Attributes
+    ----------
+    path
+        Repo-relative path, e.g. `.github/workflows/ci.yml`.
+    name
+        The `name:` key, or the file stem when the workflow does not name itself.
+    triggers
+        The `on:` block, normalized to event name -> the configuration under it, with `{}` for
+        an event written bare. All three spellings — `on: push`, `on: [push, pull_request]` and
+        the mapping form — arrive here identically, so a rule never has to ask which was used.
+    steps
+        Every step of every job, in file order, each carrying the job it came from. Flat because
+        the rules that read steps ask about all of them, and a step knows its own job.
+    """
+
+    path: str
+    name: str
+    triggers: dict[str, Any]
+    steps: tuple[Step, ...]
+
+
+def _string(value: Any) -> str | None:
+    """One YAML scalar as a string, or ``None`` when the key was absent or not a scalar."""
+    return value if isinstance(value, str) else None
+
+
+def _triggers(document: dict[Any, Any]) -> dict[str, Any]:
+    """Read a workflow's `on:` block as event name -> its configuration.
+
+    Read under two keys, because YAML 1.1 resolves an unquoted `on` to the boolean true: every
+    workflow GitHub accepts arrives with its triggers under ``True``, and `document["on"]` finds
+    them only in the rare file that quoted the key. Looking under one key alone is not a parse
+    bug that shows up later — it makes every rule about triggers pass on nothing.
+    """
+    raw = document.get("on", document.get(True))
+    if isinstance(raw, str):
+        return {raw: {}}
+    if isinstance(raw, list):
+        return {str(event): {} for event in raw}
+    if isinstance(raw, dict):
+        return {str(event): {} if config is None else config for event, config in raw.items()}
+    return {}
+
+
+def _steps(path: str, document: dict[Any, Any]) -> tuple[Step, ...]:
+    """Every step of every job in one workflow, flattened, in file order."""
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        return ()
+    steps: list[Step] = []
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        raw = job.get("steps")
+        if not isinstance(raw, list):
+            continue
+        for index, step in enumerate(raw):
+            if not isinstance(step, dict):
+                continue
+            steps.append(
+                Step(
+                    workflow=path,
+                    job=str(job_id),
+                    index=index,
+                    name=_string(step.get("name")),
+                    uses=_string(step.get("uses")),
+                    run=_string(step.get("run")),
+                )
+            )
+    return tuple(steps)
 
 
 @dataclass
@@ -195,6 +309,41 @@ class Repo:
                 continue
             entries[posixpath.normpath(f"{self.docs_dir}/{raw}")] = raw
         return entries
+
+    @cached_property
+    def workflows(self) -> tuple[Workflow, ...]:
+        """Every tracked workflow definition, parsed, in path order.
+
+        TRACKED and not globbed off disk: a workflow GitHub never sees is not a workflow, and
+        every other rule here reads the same list.
+
+        The rules that read workflows want different halves of one — what triggers it, or what
+        its steps invoke — so :class:`Workflow` exposes both and no rule parses YAML itself. A
+        file that will not parse, or that is not a mapping, becomes an empty workflow rather than
+        an exception: `_TolerantLoader` already shrugs at an unknown tag, and a derived repo's
+        unusual workflow must not turn a conformance rule into a crash.
+        """
+        found: list[Workflow] = []
+        for rel in self.tracked:
+            if not rel.startswith(WORKFLOW_DIR) or not rel.endswith(WORKFLOW_SUFFIXES):
+                continue
+            text = self.read(rel)
+            if text is None:
+                continue
+            try:
+                loaded = yaml.load(text, Loader=_TolerantLoader)
+            except yaml.YAMLError:
+                loaded = None
+            document: dict[Any, Any] = loaded if isinstance(loaded, dict) else {}
+            found.append(
+                Workflow(
+                    path=rel,
+                    name=_string(document.get("name")) or PurePosixPath(rel).stem,
+                    triggers=_triggers(document),
+                    steps=_steps(rel, document),
+                )
+            )
+        return tuple(found)
 
 
 def _walk_strings(node: Any) -> Iterator[str]:
@@ -292,7 +441,7 @@ def _glossary_entries(text: str) -> list[tuple[str, int]]:
 
 
 # --------------------------------------------------------------------------------------
-# The rules. Eight fail, two warn. Each returns what it found; nothing here exits or prints.
+# The rules. Nine fail, two warn. Each returns what it found; nothing here exits or prints.
 # --------------------------------------------------------------------------------------
 
 
@@ -550,7 +699,8 @@ def rule_skill_symlinks(repo: Repo) -> Result:
 def rule_repo_shape(repo: Repo) -> Result:
     """8. If there is a package there are tests; if there is a release workflow there is a log."""
     result = Result()
-    release = ".github/workflows/release.yml"
+    # Named once, at RELEASE_WORKFLOW, because rule 9 keys on the same file.
+    release = RELEASE_WORKFLOW
     # Both halves are CONDITIONAL, and an absent premise is vacuous rather than failing: a repo
     # with no package is not a repo that failed to have tests. That is the whole shape of the
     # rule, and it is why the notes below say which premise was absent.
@@ -583,8 +733,64 @@ def rule_repo_shape(repo: Repo) -> Result:
     return result
 
 
+def _tag_push_events(workflow: Workflow) -> list[str]:
+    """List the triggers in one workflow that pushing a tag can fire, spelled as they are written.
+
+    Three of them, and only the first is the one people think of:
+
+    - `push:` with a `tags:` or `tags-ignore:` filter — the trigger written on purpose.
+    - `push:` naming no branch filter at all. An absent filter is not "no refs", it is EVERY
+      ref, so a bare `push:` fires on a tag exactly as it fires on a branch. `paths:` narrows
+      which files, never which refs.
+    - `create`, which fires on a branch or a tag coming into existence, and a pushed tag is a
+      tag coming into existence.
+
+    A `push:` that names `branches:` or `branches-ignore:` is a branch trigger and is absent
+    from this list: naming any branch filter is what stops tags reaching the workflow.
+    """
+    fired: list[str] = []
+    if "push" in workflow.triggers:
+        config = workflow.triggers["push"]
+        config = config if isinstance(config, dict) else {}
+        if "tags" in config or "tags-ignore" in config:
+            fired.append("`on: push:` names `tags:`")
+        elif not ("branches" in config or "branches-ignore" in config):
+            fired.append("`on: push:` names no branch filter, so it fires on every ref, tags too")
+    if "create" in workflow.triggers:
+        fired.append("`on: create:` fires when a tag comes into existence")
+    return fired
+
+
+def rule_release_trigger(repo: Repo) -> Result:
+    """9. Nothing a tag push fires can trigger the publishing workflow."""
+    result = Result()
+    publishing = [w for w in repo.workflows if w.path == RELEASE_WORKFLOW]
+    if not publishing:
+        result.notes.append(
+            f"not checked: no {RELEASE_WORKFLOW}, so this repo publishes to no package index"
+        )
+        return result
+    for workflow in publishing:
+        for fired in _tag_push_events(workflow):
+            result.problems.append(
+                _problem(
+                    f"{workflow.path} can be triggered by a tag push: {fired}",
+                    "publishing is the one act in this toolchain that cannot be undone — a "
+                    "version can be neither unpublished nor reused — and `init-repo` pushes a "
+                    "first tag on a repo's opening day, so this trigger publishes from a repo "
+                    "nobody has finished naming",
+                    "trigger it on `release:` with `types: [published]`, which is a person "
+                    "publishing a GitHub Release on purpose, and add `workflow_dispatch:` for "
+                    "re-running one that failed",
+                )
+            )
+    events = ", ".join(sorted(event for w in publishing for event in w.triggers))
+    result.notes.append(f"{RELEASE_WORKFLOW} is triggered by {events or 'nothing'}")
+    return result
+
+
 def warning_init_sentinel(repo: Repo) -> Result:
-    """9. `AGENTS.md` still carries the line telling you to run `/init`."""
+    """10. `AGENTS.md` still carries the line telling you to run `/init`."""
     result = Result()
     if repo.exists(INIT_SKILL):
         result.notes.append(f"not checked: {INIT_SKILL}/ is here, and that skill is the nag")
@@ -678,6 +884,13 @@ RULES: tuple[Rule, ...] = (
     ),
     Rule(
         9,
+        "release-trigger",
+        f"{RELEASE_WORKFLOW} is triggered by publishing a GitHub Release and by nothing a tag "
+        "push fires — not `push: tags:`, not a `push:` with no branch filter, not `create`",
+        rule_release_trigger,
+    ),
+    Rule(
+        10,
         "init-sentinel",
         "AGENTS.md is still the template's generic copy",
         warning_init_sentinel,
@@ -685,9 +898,9 @@ RULES: tuple[Rule, ...] = (
     ),
 )
 
-#: Warning 10 is not a rule with a tree to inspect: it is the waiver table itself, printed on
+#: Warning 11 is not a rule with a tree to inspect: it is the waiver table itself, printed on
 #: every run. It lives in `report` because only the reporter knows what each waiver suppressed.
-WAIVER_RULE = (10, "waivers")
+WAIVER_RULE = (11, "waivers")
 
 
 def load(root: Path) -> Repo:
@@ -738,7 +951,7 @@ def _verdict(repo: Repo, rule: Rule, result: Result) -> tuple[str, list[str]]:
 
 
 def _waiver_lines(repo: Repo, results: list[tuple[Rule, Result]]) -> list[str]:
-    """Warning 10: every waiver, with what it actually suppressed.
+    """Warning 11: every waiver, with what it actually suppressed.
 
     A waiver naming no rule is called out rather than ignored, and so is one naming rule 1, which
     refuses to be waived. A waiver that quietly does nothing is the same invisible escape hatch

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -5,7 +5,7 @@
     python scripts/conformance.py [--root PATH]
 
 It states the RULE, not the file contents — a pull model, so a repo that legitimately diverges
-stays green while the shared conventions stay checked. Twelve rules: ten fail, two only warn.
+stays green while the shared conventions stay checked. Thirteen rules: eleven fail, two only warn.
 
 Three things it does on purpose:
 
@@ -36,6 +36,7 @@ from __future__ import annotations
 import argparse
 import posixpath
 import re
+import shlex
 import subprocess
 import sys
 import textwrap
@@ -55,7 +56,7 @@ import yaml
 #: neither happens.
 PLACEHOLDER = "new" + "pkg"
 
-#: Rule 1 and warning 11 are both gated on this directory, and it is the only discriminator either
+#: Rule 1 and warning 12 are both gated on this directory, and it is the only discriminator either
 #: needs. While it is here, `init-repo` has not run: the placeholder is still the repo's own name,
 #: and the auto-discovered skill is itself the nag. Once it is gone the repo claims to be its own,
 #: and both rules start checking.
@@ -83,6 +84,36 @@ RELEASE_WORKFLOW = f"{WORKFLOW_DIR}release.yml"
 #: Vale's spelling of on and off. Both forms appear in the wild; the gate accepts either.
 VALE_ON = {"YES", "TRUE", "ON"}
 VALE_OFF = {"NO", "FALSE", "OFF"}
+
+#: The command a workflow step is allowed to run, and the table its task must be declared in.
+#: Both are named here because rule 11's problem text and its fix both spell them.
+PIXI_RUN = "pixi run"
+TASK_TABLE = "[tool.pixi.tasks]"
+
+#: The `pixi run` options that take a SEPARATE value, so the token after one is that value and
+#: never the task name. The `--option=value` form needs no entry, being one token. Anything else
+#: beginning with `-` is read as a switch, so an option pixi grows later would be mistaken for the
+#: task and reported LOUDLY — the safe direction of error for a check whose whole job is to notice
+#: drift nobody announced.
+PIXI_VALUE_OPTIONS = frozenset(
+    {
+        "-e",
+        "--environment",
+        "--manifest-path",
+        "--color",
+        "--auth-file",
+        "--pypi-keyring-provider",
+        "--concurrent-solves",
+        "--concurrent-downloads",
+    }
+)
+
+#: What a `${{ ... }}` expression is replaced by before a step's command is split into tokens.
+#: GitHub substitutes these when the job runs, and `shlex` would split one into three tokens and
+#: read the middle as the task name. The stand-in is not a legal task name, so a step that names
+#: its task with an expression is reported as unresolved rather than failed.
+EXPRESSION = "${{}}"
+_EXPRESSION_RE = re.compile(r"\$\{\{.*?\}\}", re.DOTALL)
 
 _SECTION_RE = re.compile(r"^\[(?P<header>.+)\]\s*$")
 _SETTING_RE = re.compile(r"^(?P<key>[A-Za-z][^=]*?)\s*=\s*(?P<value>.*?)\s*$")
@@ -360,6 +391,17 @@ class Repo:
         return tomllib.loads(self.read("pyproject.toml") or "")
 
     @cached_property
+    def tasks(self) -> frozenset[str]:
+        """Every pixi task name the manifest declares, wherever under `[tool.pixi]` it is written.
+
+        Walked rather than read out of `[tool.pixi.tasks]` alone. pixi lets a task be declared on
+        the workspace, on a FEATURE, or on a platform target, and this repo's own `docs-build`
+        lives on the `docs` feature — so a rule reading one table would fail the docs job of a
+        workflow that is entirely correct.
+        """
+        return frozenset(_task_names(self.manifest.get("tool", {}).get("pixi")))
+
+    @cached_property
     def workflows(self) -> tuple[Workflow, ...]:
         """Every tracked workflow definition, parsed, in path order.
 
@@ -410,6 +452,58 @@ def _walk_strings(node: Any) -> Iterator[str]:
     elif isinstance(node, dict):
         for value in node.values():  # pyright: ignore[reportUnknownVariableType]
             yield from _walk_strings(value)
+
+
+def _task_names(node: Any) -> Iterator[str]:
+    """Every key of every `tasks` table at any depth, wherever pixi accepts one.
+
+    One walk rather than four reads: a task may be declared on the workspace, on a feature, on a
+    platform target, or on a target under a feature.
+    """
+    if not isinstance(node, dict):
+        return
+    for key, value in node.items():  # pyright: ignore[reportUnknownVariableType]
+        if key == "tasks" and isinstance(value, dict):
+            yield from (str(name) for name in value)  # pyright: ignore[reportUnknownVariableType]
+        else:
+            yield from _task_names(value)
+
+
+def _invoked_task(run: str) -> str | None:
+    """Read the pixi task one step's `run:` script invokes, or ``None`` when it runs a command.
+
+    The accepted shape is `pixi run`, any pixi options, and one more token — the task. Options are
+    skipped on both sides of `run`, so `pixi run -e test test` and `pixi run docs-build` arrive
+    the same way and no spelling is privileged.
+
+    Nothing may follow the task, and that is the strict half of the rule rather than an oversight.
+    A step passing arguments of its own is the drift this rule is about, one level down: the
+    arguments a task runs with belong in the task, which is exactly where `check-static` keeps its
+    own list. A script of several lines, or two commands joined by `&&`, leaves tokens after the
+    task and lands here too.
+    """
+    script = _EXPRESSION_RE.sub(EXPRESSION, run)
+    try:
+        tokens = shlex.split(script, comments=True)
+    except ValueError:
+        # An unbalanced quote. Not a crash and not a pass: whatever it is, it is not this shape.
+        return None
+    if not tokens or tokens[0] != "pixi":
+        return None
+    index = _skip_options(tokens, 1)
+    if index >= len(tokens) or tokens[index] != "run":
+        return None
+    index = _skip_options(tokens, index + 1)
+    if len(tokens) - index != 1:
+        return None
+    return tokens[index]
+
+
+def _skip_options(tokens: list[str], index: int) -> int:
+    """Advance past the options at `index`, taking the value of one that has a separate value."""
+    while index < len(tokens) and tokens[index].startswith("-"):
+        index += 2 if tokens[index] in PIXI_VALUE_OPTIONS else 1
+    return index
 
 
 def _front_matter(text: str) -> dict[str, Any] | None:
@@ -500,7 +594,7 @@ def _has_table(manifest: dict[str, Any], dotted: str) -> bool:
 
 
 # --------------------------------------------------------------------------------------
-# The rules. Ten fail, two warn. Each returns what it found; nothing here exits or prints.
+# The rules. Eleven fail, two warn. Each returns what it found; nothing here exits or prints.
 # --------------------------------------------------------------------------------------
 
 
@@ -848,35 +942,6 @@ def rule_release_trigger(repo: Repo) -> Result:
     return result
 
 
-def warning_init_sentinel(repo: Repo) -> Result:
-    """10. `AGENTS.md` still carries the line telling you to run `/init`."""
-    result = Result()
-    if repo.exists(INIT_SKILL):
-        result.notes.append(f"not checked: {INIT_SKILL}/ is here, and that skill is the nag")
-        return result
-    text = repo.read("AGENTS.md")
-    if text is None:
-        result.notes.append("not checked: no AGENTS.md")
-        return result
-    # The sentinel is a blockquote line naming `/init`. It is phrased as an instruction and it
-    # says to delete itself, so replacing the file is what makes this warning stop — "done" needs
-    # no separate step. This WARNS and never fails: a new repo must not start red for a task its
-    # owner is allowed to defer.
-    if any(line.lstrip().startswith(">") and "/init" in line for line in text.splitlines()):
-        result.problems.append(
-            _problem(
-                "AGENTS.md still carries the `/init` sentinel",
-                "the file is the template's generic copy: it says how ANY Liu Lab repo works, "
-                "not what this one does, and an agent that reads it will act on a description "
-                "that was never true here",
-                "run `/init`, then delete the sentinel line. This is a warning, not a failure",
-            )
-        )
-    else:
-        result.notes.append("AGENTS.md no longer carries it")
-    return result
-
-
 def rule_single_toolchain(repo: Repo) -> Result:
     """10. No second toolchain is configured: pixi and the manifest are the only ones."""
     result = Result()
@@ -916,6 +981,89 @@ def rule_single_toolchain(repo: Repo) -> Result:
         f"{len(SECOND_TOOLCHAINS)} second toolchain(s) looked for across "
         f"{len(repo.tracked)} tracked path(s) and pyproject.toml: {names}"
     )
+    return result
+
+
+def rule_workflow_step_tasks(repo: Repo) -> Result:
+    """11. Every workflow step that runs anything invokes a task the manifest declares."""
+    result = Result()
+    # `uses:` steps are not examined at all, and that is the rule and not an exemption: an action
+    # is a dependency the workflow pulls in, not a step of this repo's own build, and there is no
+    # task for it to have been.
+    running = [step for w in repo.workflows for step in w.steps if step.run is not None]
+    if not running:
+        result.notes.append("not checked: no tracked workflow has a step that runs a command")
+        return result
+    unresolved = 0
+    for step in running:
+        where = f"{step.workflow} job `{step.job}` step {step.index}"
+        if step.name:
+            where += f" ({step.name})"
+        task = _invoked_task(step.run or "")
+        if task is None:
+            result.problems.append(
+                _problem(
+                    f"{where} runs a command rather than `{PIXI_RUN} <task>`",
+                    "the step list lives in the task table so that CI and a laptop run the same "
+                    "steps by construction. A step that spells out a command runs something no "
+                    "local `pixi run` does, and both stay green while they quietly stop being the "
+                    "same claim — until someone notices the two lists disagree, months later",
+                    f"declare what it runs as a task in {TASK_TABLE}, arguments included, and "
+                    f"make the step `{PIXI_RUN} <that task>`",
+                )
+            )
+        elif EXPRESSION in task:
+            unresolved += 1
+        elif task not in repo.tasks:
+            result.problems.append(
+                _problem(
+                    f"{where} invokes `{task}`, which this repo declares no task by",
+                    "a step naming a task nobody declared cannot run at all, and the workflow "
+                    "that finds out is often one that runs rarely — the publish, the scheduled "
+                    "job — so the break surfaces on the day it costs the most. It reads as if it "
+                    "were following the convention, which is what makes it worse than a command",
+                    f"declare `{task}` in pyproject.toml under {TASK_TABLE}, or point the step at "
+                    "a task that is declared",
+                )
+            )
+    result.notes.append(
+        f"{len(running)} step(s) that run a command, across {len(repo.workflows)} workflow(s), "
+        f"against {len(repo.tasks)} declared task(s)"
+    )
+    if unresolved:
+        result.notes.append(
+            f"{unresolved} step(s) name their task with a `" + EXPRESSION + "` expression, which "
+            "GitHub resolves when the job runs and this cannot"
+        )
+    return result
+
+
+def warning_init_sentinel(repo: Repo) -> Result:
+    """12. `AGENTS.md` still carries the line telling you to run `/init`."""
+    result = Result()
+    if repo.exists(INIT_SKILL):
+        result.notes.append(f"not checked: {INIT_SKILL}/ is here, and that skill is the nag")
+        return result
+    text = repo.read("AGENTS.md")
+    if text is None:
+        result.notes.append("not checked: no AGENTS.md")
+        return result
+    # The sentinel is a blockquote line naming `/init`. It is phrased as an instruction and it
+    # says to delete itself, so replacing the file is what makes this warning stop — "done" needs
+    # no separate step. This WARNS and never fails: a new repo must not start red for a task its
+    # owner is allowed to defer.
+    if any(line.lstrip().startswith(">") and "/init" in line for line in text.splitlines()):
+        result.problems.append(
+            _problem(
+                "AGENTS.md still carries the `/init` sentinel",
+                "the file is the template's generic copy: it says how ANY Liu Lab repo works, "
+                "not what this one does, and an agent that reads it will act on a description "
+                "that was never true here",
+                "run `/init`, then delete the sentinel line. This is a warning, not a failure",
+            )
+        )
+    else:
+        result.notes.append("AGENTS.md no longer carries it")
     return result
 
 
@@ -999,6 +1147,14 @@ RULES: tuple[Rule, ...] = (
     ),
     Rule(
         11,
+        "workflow-step-tasks",
+        f"every workflow step that runs a command invokes a declared task — `{PIXI_RUN} <task>` "
+        f"and nothing else, with the task in {TASK_TABLE}, so the step list cannot drift from the "
+        "one a laptop runs. A step that `uses:` an action is not a step of this repo's build",
+        rule_workflow_step_tasks,
+    ),
+    Rule(
+        12,
         "init-sentinel",
         "AGENTS.md is still the template's generic copy",
         warning_init_sentinel,
@@ -1006,9 +1162,9 @@ RULES: tuple[Rule, ...] = (
     ),
 )
 
-#: Warning 12 is not a rule with a tree to inspect: it is the waiver table itself, printed on
+#: Warning 13 is not a rule with a tree to inspect: it is the waiver table itself, printed on
 #: every run. It lives in `report` because only the reporter knows what each waiver suppressed.
-WAIVER_RULE = (12, "waivers")
+WAIVER_RULE = (13, "waivers")
 
 
 def load(root: Path) -> Repo:
@@ -1059,7 +1215,7 @@ def _verdict(repo: Repo, rule: Rule, result: Result) -> tuple[str, list[str]]:
 
 
 def _waiver_lines(repo: Repo, results: list[tuple[Rule, Result]]) -> list[str]:
-    """Warning 12: every waiver, with what it actually suppressed.
+    """Warning 13: every waiver, with what it actually suppressed.
 
     A waiver naming no rule is called out rather than ignored, and so is one naming rule 1, which
     refuses to be waived. A waiver that quietly does nothing is the same invisible escape hatch

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -5,7 +5,7 @@
     python scripts/conformance.py [--root PATH]
 
 It states the RULE, not the file contents — a pull model, so a repo that legitimately diverges
-stays green while the shared conventions stay checked. Ten rules: eight fail, two only warn.
+stays green while the shared conventions stay checked. Eleven rules: nine fail, two only warn.
 
 Three things it does on purpose:
 
@@ -196,6 +196,12 @@ class Repo:
             entries[posixpath.normpath(f"{self.docs_dir}/{raw}")] = raw
         return entries
 
+    @cached_property
+    def pyproject(self) -> dict[str, Any]:
+        """`pyproject.toml` as a mapping. `load` already refused a tree that has none."""
+        text = self.read("pyproject.toml")
+        return tomllib.loads(text) if text is not None else {}
+
 
 def _walk_strings(node: Any) -> Iterator[str]:
     """Every string value in a `nav:` tree, at any depth.
@@ -291,8 +297,68 @@ def _glossary_entries(text: str) -> list[tuple[str, int]]:
     return entries
 
 
+#: A `major.minor` anywhere in a version a tool spells out — `3.13`, `3.13.*`, `>=3.13,<3.14`.
+_MINOR_RE = re.compile(r"(?P<major>\d+)\.(?P<minor>\d+)")
+#: The lowest version a `requires-python` specifier admits. `<` and `!=` name no floor at all.
+_FLOOR_RE = re.compile(r"(?:>=|~=|==)\s*(?P<major>\d+)\.(?P<minor>\d+)")
+#: Ruff's spelling: one digit of major, the rest minor, so `py313` is 3.13 and `py39` is 3.9.
+_RUFF_TARGET_RE = re.compile(r"^py(?P<major>\d)(?P<minor>\d+)$")
+
+#: Where a repo writes a LANGUAGE LEVEL down, beyond the floor and the pin: the table, the key,
+#: the pattern that reads it, and how that tool spells a level back. A repo that adds a tool adds
+#: one line here. Trove classifiers are deliberately absent — `Programming Language :: Python ::
+#: 3.12` is a list of versions a package supports, not a level, and a library names several.
+_LEVEL_SITES: tuple[tuple[tuple[str, ...], str, re.Pattern[str], str], ...] = (
+    (("tool", "ruff"), "target-version", _RUFF_TARGET_RE, "py{0}{1}"),
+    (("tool", "pyright"), "pythonVersion", _MINOR_RE, "{0}.{1}"),
+    (("tool", "mypy"), "python_version", _MINOR_RE, "{0}.{1}"),
+)
+
+
+def _table(root: dict[str, Any], *path: str) -> dict[str, Any]:
+    """One nested table of a parsed TOML file, or an empty mapping where the path runs out."""
+    node: Any = root
+    for key in path:
+        node = node.get(key) if isinstance(node, dict) else None
+    return node if isinstance(node, dict) else {}
+
+
+def _version(text: str, pattern: re.Pattern[str]) -> tuple[int, int] | None:
+    """Read the (major, minor) a pattern finds in one declaration.
+
+    ``None`` when the pattern finds none, which is a declaration nothing can be held to.
+    """
+    match = pattern.search(text.strip())
+    return (int(match["major"]), int(match["minor"])) if match else None
+
+
+def _spell(level: tuple[int, int]) -> str:
+    """Write a (major, minor) the way a person says it."""
+    return f"{level[0]}.{level[1]}"
+
+
+def _python_pins(pyproject: dict[str, Any]) -> dict[str, str]:
+    """Every pixi `python` pin, keyed by the table header that holds it.
+
+    Features are read as well as the default table, because a repo that really supports a range
+    gives its floor an environment to resolve in, and rule 10 says so in its notes. A pin may be
+    written `python = "3.13.*"` or `python = { version = "3.13.*" }`; both are the same claim.
+    """
+    tables: set[tuple[str, ...]] = {("tool", "pixi", "dependencies")}
+    for name in _table(pyproject, "tool", "pixi", "feature"):
+        tables.add(("tool", "pixi", "feature", name, "dependencies"))
+    pins: dict[str, str] = {}
+    for path in sorted(tables):
+        value: Any = _table(pyproject, *path).get("python")
+        if isinstance(value, dict):
+            value = value.get("version")
+        if isinstance(value, str):
+            pins[f"[{'.'.join(path)}] python"] = value
+    return pins
+
+
 # --------------------------------------------------------------------------------------
-# The rules. Eight fail, two warn. Each returns what it found; nothing here exits or prints.
+# The rules. Nine fail, two warn. Each returns what it found; nothing here exits or prints.
 # --------------------------------------------------------------------------------------
 
 
@@ -612,6 +678,105 @@ def warning_init_sentinel(repo: Repo) -> Result:
     return result
 
 
+def rule_python_version_agreement(repo: Repo) -> Result:
+    """10. Every declared Python version agrees with the floor and with the pinned interpreter."""
+    result = Result()
+    # AGREEMENT, never a count. A repo supporting a range of Pythons declares a floor below its
+    # pin and holds its tools to the floor, and a rule that counted declarations would fail it —
+    # which would make this template unusable for a library. What cannot legitimately differ is
+    # what the declarations SAY.
+    pins = _python_pins(repo.pyproject)
+    pinned: dict[str, tuple[int, int]] = {}
+    for where, spelling in pins.items():
+        level = _version(spelling, _MINOR_RE)
+        if level is not None:
+            pinned[where] = level
+    if not pinned:
+        if pins:
+            spelled = ", ".join(f"{where} is `{pins[where]}`" for where in sorted(pins))
+            reason = f"no pixi `python` pin names a minor version: {spelled}"
+        else:
+            reason = "no `python` in [tool.pixi.dependencies] or in any pixi feature"
+        result.notes.append(
+            f"not checked: {reason} — this repo names no interpreter for the other declarations "
+            "to agree with"
+        )
+        return result
+
+    requires = _table(repo.pyproject, "project").get("requires-python")
+    requires = requires if isinstance(requires, str) else None
+    floor = _version(requires, _FLOOR_RE) if requires is not None else None
+    lowest = min(pinned.values())
+    for where, level in sorted(pinned.items()):
+        if floor is not None and level < floor:
+            result.problems.append(
+                _problem(
+                    f"{where} `{pins[where]}` pins {_spell(level)}, below the "
+                    f"[project] requires-python floor `{requires}`",
+                    "the repo runs an interpreter its own package metadata says it does not "
+                    "support, so every gate is green on a version pip would refuse to install on",
+                    f"raise the pin to {_spell(floor)}, or lower requires-python to "
+                    f">={_spell(level)}",
+                )
+            )
+
+    # The language level a tool holds the code to is the OLDEST interpreter the repo supports:
+    # the floor where one is declared, and otherwise the lowest thing pinned.
+    if floor is not None:
+        wanted, source = floor, f"[project] requires-python `{requires}`"
+    else:
+        wanted = lowest
+        at_lowest = next(where for where, level in sorted(pinned.items()) if level == lowest)
+        source = f"{at_lowest} `{pins[at_lowest]}`"
+    declared = [f"[project] requires-python `{requires}`"] if requires is not None else []
+    declared += [f"{where} `{pins[where]}`" for where in sorted(pinned)]
+    for path, key, pattern, spelling in _LEVEL_SITES:
+        table = _table(repo.pyproject, *path)
+        if key not in table:
+            continue
+        where = f"[{'.'.join(path)}] {key}"
+        said = str(table[key])
+        declared.append(f"{where} `{said}`")
+        level = _version(said, pattern)
+        if level is None:
+            result.problems.append(
+                _problem(
+                    f"{where} is `{said}`, which names no Python version",
+                    "a level this check cannot read is a level nothing can hold to the floor, and "
+                    f"{path[-1]} may well be reading it as something else again",
+                    f"write it the way {path[-1]} spells a version, or delete the key",
+                )
+            )
+            continue
+        if level != wanted:
+            result.problems.append(
+                _problem(
+                    f"{where} `{said}` says {_spell(level)}, and {source} says {_spell(wanted)}",
+                    "this is the language level the tool holds the code to, and it has to be the "
+                    "oldest interpreter the repo supports. Above the floor it lets through syntax "
+                    "that fails on a version the package claims to install on; below it the tool "
+                    "rejects code the repo is allowed to write",
+                    f'write `{key} = "{spelling.format(*wanted)}"`, or delete the key — with no '
+                    f"{key} the level is derived from the floor and the pin",
+                )
+            )
+
+    result.notes.append(f"{len(declared)} declaration(s): {'; '.join(declared)}")
+    # The one thing this rule CANNOT see. A floor below every pin is either a range the repo
+    # deliberately supports or a floor nobody lowered when the pin moved up, and the declarations
+    # read identically in both cases. Saying so is the point: a rule that quietly cannot tell them
+    # apart is worse than one that reports which it checked.
+    if floor is not None and floor < lowest:
+        result.notes.append(
+            f"not checked: whether {_spell(floor)} is ever resolved or tested. Nothing here pins "
+            f"it, so a range this repo supports on purpose and a floor left behind by a raised "
+            f"pin look the same — pin {_spell(floor)} in a pixi feature to make the claim real"
+        )
+    elif floor is not None and len(set(pinned.values())) > 1:
+        result.notes.append(f"the floor {_spell(floor)} is itself pinned, so pixi resolves it")
+    return result
+
+
 @dataclass(frozen=True)
 class Rule:
     """One rule, its number, and the one-line statement printed when it fails."""
@@ -683,11 +848,18 @@ RULES: tuple[Rule, ...] = (
         warning_init_sentinel,
         warns_only=True,
     ),
+    Rule(
+        10,
+        "python-version-agreement",
+        "every pixi python pin satisfies the requires-python floor, and every tool that writes a "
+        "language level down writes the floor — agreement, not a count, so a range still passes",
+        rule_python_version_agreement,
+    ),
 )
 
-#: Warning 10 is not a rule with a tree to inspect: it is the waiver table itself, printed on
+#: Warning 11 is not a rule with a tree to inspect: it is the waiver table itself, printed on
 #: every run. It lives in `report` because only the reporter knows what each waiver suppressed.
-WAIVER_RULE = (10, "waivers")
+WAIVER_RULE = (11, "waivers")
 
 
 def load(root: Path) -> Repo:
@@ -788,6 +960,9 @@ def report(repo: Repo, results: list[tuple[Rule, Result]]) -> int:
                     width=110,
                     initial_indent=head if index == 0 else " " * len(head),
                     subsequent_indent=" " * len(head),
+                    # Notes are mostly identifiers — `target-version`, `agent-docs`, a path — and
+                    # a wrap inside one leaves a name no reader can grep for.
+                    break_on_hyphens=False,
                 )
             )
 

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -5,7 +5,7 @@
     python scripts/conformance.py [--root PATH]
 
 It states the RULE, not the file contents — a pull model, so a repo that legitimately diverges
-stays green while the shared conventions stay checked. Ten rules: eight fail, two only warn.
+stays green while the shared conventions stay checked. Eleven rules: nine fail, two only warn.
 
 Three things it does on purpose:
 
@@ -82,6 +82,50 @@ _SKILL_FILE_RE = re.compile(r"^skills/[^/]+/SKILL\.md$")
 _SKILL_DIR_RES = (
     re.compile(r"^skills/(?P<name>[^/]+)/"),
     re.compile(r"^\.(?:claude|agents)/skills/(?P<name>[^/]+)(?:/|$)"),
+)
+
+
+@dataclass(frozen=True)
+class SecondToolchain:
+    """One toolchain other than pixi, and where it would declare a dependency version.
+
+    Attributes
+    ----------
+    tool
+        The tool named in the failure, and listed in the note that says what was looked for.
+    path
+        A regex FULL-matched against a repo-relative tracked path. A pattern with no `/` in it
+        therefore matches at the repo root and nowhere else, which is where a resolver reads:
+        `tests/fixtures/requirements.txt` is a test's input, not this repo's dependencies.
+    table
+        A dotted table in `pyproject.toml`, for a tool that declares versions in the manifest
+        instead of a file of its own — a second build backend's dependency section.
+    """
+
+    tool: str
+    path: str = ""
+    table: str = ""
+
+
+#: Every second place a dependency version can be declared. Rule 10 reads this and nothing else,
+#: so covering one more tool is one more line here.
+#:
+#: It is a constant and not a `[tool.liulab.*]` key because it is not a claim a repo makes about
+#: itself: the rule is the same in every Liu Lab repo, and a repo that must keep one of these has
+#: `[tool.liulab.waived]`, which is printed on every run. A manifest list could be emptied
+#: instead, and an escape hatch nobody can see is the thing this file exists to prevent.
+#:
+#: Lockfiles are named per tool, never `*.lock`: `pixi.lock` is the lock this rule protects.
+#: `setup.cfg` is absent because it commonly carries only tool configuration and no dependency.
+SECOND_TOOLCHAINS: tuple[SecondToolchain, ...] = (
+    SecondToolchain("pre-commit", path=r"\.pre-commit-config\.ya?ml"),
+    SecondToolchain("pip", path=r"[^/]*requirements[^/]*\.txt|requirements/[^/]+\.txt"),
+    SecondToolchain("conda", path=r"[^/]*environment[^/]*\.ya?ml"),
+    SecondToolchain("pipenv", path=r"Pipfile(\.lock)?"),
+    SecondToolchain("setuptools", path=r"setup\.py"),
+    SecondToolchain("poetry", path=r"poetry\.lock", table="tool.poetry"),
+    SecondToolchain("uv", path=r"uv\.lock", table="tool.uv"),
+    SecondToolchain("pdm", path=r"pdm\.lock", table="tool.pdm"),
 )
 
 
@@ -196,6 +240,11 @@ class Repo:
             entries[posixpath.normpath(f"{self.docs_dir}/{raw}")] = raw
         return entries
 
+    @cached_property
+    def manifest(self) -> dict[str, Any]:
+        """`pyproject.toml`, parsed. `load` refused to build this repo unless it parses."""
+        return tomllib.loads(self.read("pyproject.toml") or "")
+
 
 def _walk_strings(node: Any) -> Iterator[str]:
     """Every string value in a `nav:` tree, at any depth.
@@ -291,8 +340,18 @@ def _glossary_entries(text: str) -> list[tuple[str, int]]:
     return entries
 
 
+def _has_table(manifest: dict[str, Any], dotted: str) -> bool:
+    """Whether a dotted table — `tool.poetry` — is present in a parsed manifest."""
+    node: Any = manifest
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    return True
+
+
 # --------------------------------------------------------------------------------------
-# The rules. Eight fail, two warn. Each returns what it found; nothing here exits or prints.
+# The rules. Nine fail, two warn. Each returns what it found; nothing here exits or prints.
 # --------------------------------------------------------------------------------------
 
 
@@ -612,6 +671,48 @@ def warning_init_sentinel(repo: Repo) -> Result:
     return result
 
 
+def rule_single_toolchain(repo: Repo) -> Result:
+    """10. No second toolchain is configured: pixi and the manifest are the only ones."""
+    result = Result()
+    # One why for every marker, because it is one failure: the class, not the tool.
+    why = (
+        "two resolvers can disagree, and it fails silently rather than loudly: a version "
+        "declared here is one `pixi.lock` never sees, so an environment built from it and the "
+        "environment the gate runs in differ while both look correct. pyproject.toml is the "
+        "single source of truth for dependencies, environments and tasks"
+    )
+    for marker in SECOND_TOOLCHAINS:
+        if marker.path:
+            for rel in repo.tracked:
+                if re.fullmatch(marker.path, rel):
+                    result.problems.append(
+                        _problem(
+                            f"{rel} declares dependencies for {marker.tool}, a second toolchain",
+                            why,
+                            f"delete {rel} and declare what it pinned in pyproject.toml — "
+                            "`[tool.pixi.dependencies]` for a package, `[tool.pixi.tasks]` for a "
+                            "command — then run `pixi install`",
+                        )
+                    )
+        if marker.table and _has_table(repo.manifest, marker.table):
+            result.problems.append(
+                _problem(
+                    f"pyproject.toml has [{marker.table}], which configures {marker.tool}",
+                    why,
+                    f"delete [{marker.table}] and every table under it, declare what it pinned "
+                    "under `[tool.pixi.dependencies]`, then run `pixi install`",
+                )
+            )
+    # This rule is never vacuous — the list is always there and so is the manifest — but a run
+    # still has to say WHICH second toolchains it knew to look for, or a green means nothing.
+    names = ", ".join(marker.tool for marker in SECOND_TOOLCHAINS)
+    result.notes.append(
+        f"{len(SECOND_TOOLCHAINS)} second toolchain(s) looked for across "
+        f"{len(repo.tracked)} tracked path(s) and pyproject.toml: {names}"
+    )
+    return result
+
+
 @dataclass(frozen=True)
 class Rule:
     """One rule, its number, and the one-line statement printed when it fails."""
@@ -683,11 +784,18 @@ RULES: tuple[Rule, ...] = (
         warning_init_sentinel,
         warns_only=True,
     ),
+    Rule(
+        10,
+        "single-toolchain",
+        "no second toolchain is configured — no pre-commit config, requirements file, conda "
+        "environment or foreign resolver's table declares a version the pixi lock never sees",
+        rule_single_toolchain,
+    ),
 )
 
-#: Warning 10 is not a rule with a tree to inspect: it is the waiver table itself, printed on
+#: Warning 11 is not a rule with a tree to inspect: it is the waiver table itself, printed on
 #: every run. It lives in `report` because only the reporter knows what each waiver suppressed.
-WAIVER_RULE = (10, "waivers")
+WAIVER_RULE = (11, "waivers")
 
 
 def load(root: Path) -> Repo:
@@ -738,7 +846,7 @@ def _verdict(repo: Repo, rule: Rule, result: Result) -> tuple[str, list[str]]:
 
 
 def _waiver_lines(repo: Repo, results: list[tuple[Rule, Result]]) -> list[str]:
-    """Warning 10: every waiver, with what it actually suppressed.
+    """Warning 11: every waiver, with what it actually suppressed.
 
     A waiver naming no rule is called out rather than ignored, and so is one naming rule 1, which
     refuses to be waived. A waiver that quietly does nothing is the same invisible escape hatch

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -7,7 +7,7 @@ checked by no rule at all, with zero alerts and green CI. So the claim these tes
 
 Every test builds a tmp_path tree that is correct in every respect but one, and asserts the run
 marks THAT rule FAIL and names the offending file. The rule name alone would prove nothing: the
-status table prints all ten names on every run, passing or failing, so the assertions read the
+status table prints all eleven names on every run, passing or failing, so the assertions read the
 status word out of the table rather than grepping the output for a name.
 
 Conformance is invoked as a SUBPROCESS, so what is under test is the command an agent runs and
@@ -157,7 +157,7 @@ def statuses(proc: subprocess.CompletedProcess[str]) -> dict[str, str]:
     """The verdict the run gave each rule, read off its own status table.
 
     Asserting on the status word rather than on the presence of a rule NAME is the point: the
-    table prints all ten names on every run, so `"repo-shape" in output` is true of a green run
+    table prints all eleven names on every run, so `"repo-shape" in output` is true of a green run
     and would prove nothing at all.
     """
     found: dict[str, str] = {}
@@ -187,6 +187,7 @@ def test_the_fixture_tree_passes_every_rule(repo: Path) -> None:
         "skill-symlinks",
         "repo-shape",
         "init-sentinel",
+        "single-toolchain",
         "waivers",
     }
     assert verdicts["placeholder-rename"] == "ok"  # live, not gated off
@@ -248,7 +249,7 @@ def test_rule_1_refuses_to_be_waived(repo: Path) -> None:
     assert proc.returncode == 1
     assert statuses(proc)["placeholder-rename"] == "FAIL"
     assert "cannot be waived" in proc.stderr
-    assert "REFUSED" in proc.stdout  # and warning 10 still prints it
+    assert "REFUSED" in proc.stdout  # and warning 11 still prints it
 
 
 def test_rule_2_fires_on_a_page_that_is_not_excluded_from_search(repo: Path) -> None:
@@ -434,7 +435,7 @@ def test_a_waiver_suppresses_its_rule_and_is_still_printed(repo: Path) -> None:
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert statuses(proc)["glossary-entry-length"] == "waived"
     assert f"1 problem(s) suppressed: {reason}" in flat(proc.stdout)
-    # and warning 10 prints it a second time, in the waiver table
+    # and warning 11 prints it a second time, in the waiver table
     assert f"glossary-entry-length: 1 problem(s) suppressed — {reason}" in flat(proc.stdout)
 
 
@@ -467,4 +468,70 @@ def test_every_failure_is_reported_and_not_just_the_first(repo: Path) -> None:
     assert verdicts["agent-docs-unpublished"] == "FAIL"
     assert verdicts["skill-file-location"] == "FAIL"
     assert verdicts["repo-shape"] == "FAIL"
-    assert "3 of 8 rules failed" in proc.stderr
+    assert "3 of 9 rules failed" in proc.stderr
+
+
+def test_rule_10_fires_on_a_pre_commit_configuration(repo: Path) -> None:
+    write(repo, ".pre-commit-config.yaml", "repos:\n  - repo: local\n    hooks: []\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["single-toolchain"] == "FAIL"
+    assert ".pre-commit-config.yaml declares dependencies for pre-commit" in proc.stderr
+    assert "pyproject.toml is the single source of truth" in flat(proc.stderr)
+
+
+def test_rule_10_fires_on_a_requirements_file(repo: Path) -> None:
+    # Not `requirements.txt`: the marker covers the family, and a rule written for the one
+    # spelling one repo happened to use would pass this tree.
+    write(repo, "requirements-dev.txt", "ruff==0.6.0\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["single-toolchain"] == "FAIL"
+    assert "requirements-dev.txt declares dependencies for pip" in proc.stderr
+
+
+def test_rule_10_fires_on_a_conda_environment_file(repo: Path) -> None:
+    write(repo, "environment.yml", "name: example\ndependencies:\n  - python=3.13\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["single-toolchain"] == "FAIL"
+    assert "environment.yml declares dependencies for conda" in proc.stderr
+
+
+def test_rule_10_fires_on_a_second_build_backends_dependency_section(repo: Path) -> None:
+    # No file of its own: the versions are a table in the same manifest, which is the shape a
+    # rule that only looked at filenames would miss.
+    write(repo, "pyproject.toml", PYPROJECT + '\n[tool.poetry.dependencies]\nrequests = "*"\n')
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["single-toolchain"] == "FAIL"
+    assert "pyproject.toml has [tool.poetry], which configures poetry" in proc.stderr
+
+
+def test_rule_10_fires_on_another_resolvers_lockfile(repo: Path) -> None:
+    write(repo, "uv.lock", "version = 1\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["single-toolchain"] == "FAIL"
+    assert "uv.lock declares dependencies for uv" in proc.stderr
+
+
+def test_rule_10_leaves_the_pixi_lock_and_a_fixture_alone(repo: Path) -> None:
+    # `pixi.lock` is the lock this rule protects, and a requirements file BELOW the root is some
+    # test's input, not this repo's dependencies. Markers are named per tool and root-anchored so
+    # that neither of these is a failure.
+    write(repo, "pixi.lock", "version: 6\n")
+    write(repo, "tests/fixtures/requirements.txt", "requests==2.0.0\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["single-toolchain"] == "ok"
+
+
+def test_rule_10_says_which_second_toolchains_it_looked_for(repo: Path) -> None:
+    # This rule can never be vacuous, so it never prints `--`. It still has to say what it knew
+    # to look for, or its green means only that nothing on an unstated list was found.
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["single-toolchain"] == "ok"
+    assert "8 second toolchain(s) looked for" in flat(proc.stdout)
+    assert "pre-commit, pip, conda, pipenv, setuptools, poetry, uv, pdm" in flat(proc.stdout)

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -7,8 +7,8 @@ checked by no rule at all, with zero alerts and green CI. So the claim these tes
 
 Every test builds a tmp_path tree that is correct in every respect but one, and asserts the run
 marks THAT rule FAIL and names the offending file. The rule name alone would prove nothing: the
-status table prints all ten names on every run, passing or failing, so the assertions read the
-status word out of the table rather than grepping the output for a name.
+status table prints all eleven names on every run, passing or failing, so the assertions
+read the status word out of the table rather than grepping the output for a name.
 
 Conformance is invoked as a SUBPROCESS, so what is under test is the command an agent runs and
 CI runs, not an internal function that could be refactored into something the command no longer
@@ -157,8 +157,8 @@ def statuses(proc: subprocess.CompletedProcess[str]) -> dict[str, str]:
     """The verdict the run gave each rule, read off its own status table.
 
     Asserting on the status word rather than on the presence of a rule NAME is the point: the
-    table prints all ten names on every run, so `"repo-shape" in output` is true of a green run
-    and would prove nothing at all.
+    table prints all eleven names on every run, so `"repo-shape" in output` is true of a green
+    run and would prove nothing at all.
     """
     found: dict[str, str] = {}
     for line in proc.stdout.splitlines():
@@ -187,6 +187,7 @@ def test_the_fixture_tree_passes_every_rule(repo: Path) -> None:
         "skill-symlinks",
         "repo-shape",
         "init-sentinel",
+        "python-version-agreement",
         "waivers",
     }
     assert verdicts["placeholder-rename"] == "ok"  # live, not gated off
@@ -467,4 +468,146 @@ def test_every_failure_is_reported_and_not_just_the_first(repo: Path) -> None:
     assert verdicts["agent-docs-unpublished"] == "FAIL"
     assert verdicts["skill-file-location"] == "FAIL"
     assert verdicts["repo-shape"] == "FAIL"
-    assert "3 of 8 rules failed" in proc.stderr
+    assert "3 of 9 rules failed" in proc.stderr
+
+
+def pyproject_python(
+    *,
+    floor: str | None = None,
+    pin: str | None = None,
+    feature_pin: str | None = None,
+    ruff: str | None = None,
+    pyright: str | None = None,
+) -> str:
+    """The fixture's pyproject plus whichever Python declarations one test wants.
+
+    A builder rather than five literals because rule 10 is about the COMBINATION: every test
+    below differs only in which sites it fills in and what each of them says.
+    """
+    text = PYPROJECT
+    if floor is not None:
+        text = text.replace('name = "example"', f'name = "example"\nrequires-python = "{floor}"')
+    if pin is not None:
+        text += f'\n[tool.pixi.dependencies]\npython = "{pin}"\n'
+    if feature_pin is not None:
+        text += f'\n[tool.pixi.feature.floor.dependencies]\npython = "{feature_pin}"\n'
+    if ruff is not None:
+        text += f'\n[tool.ruff]\ntarget-version = "{ruff}"\n'
+    if pyright is not None:
+        text += f'\n[tool.pyright]\npythonVersion = "{pyright}"\n'
+    return text
+
+
+def test_rule_10_is_vacuous_when_the_repo_pins_no_interpreter(repo: Path) -> None:
+    # The fixture declares no Python at all. With no pinned interpreter there is nothing for the
+    # other declarations to agree WITH, so the run has to say it checked nothing.
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["python-version-agreement"] == "--"
+    assert "not checked: no `python` in [tool.pixi.dependencies] or in any pixi feature" in flat(
+        proc.stdout
+    )
+
+
+def test_rule_10_passes_on_a_floor_and_a_pin_that_agree(repo: Path) -> None:
+    # Two declarations, which is what the template ships: ruff takes its target from the floor
+    # and pyright takes its version from the interpreter, so neither writes a level down.
+    write(repo, "pyproject.toml", pyproject_python(floor=">=3.13", pin="3.13.*"))
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["python-version-agreement"] == "ok"
+    assert "2 declaration(s)" in flat(proc.stdout)
+
+
+def test_rule_10_passes_when_four_declarations_agree(repo: Path) -> None:
+    # Writing the derived levels down is allowed; disagreeing with the floor is not. A rule that
+    # counted declarations would fail this tree, and this tree is fine.
+    write(
+        repo,
+        "pyproject.toml",
+        pyproject_python(floor=">=3.13", pin="3.13.*", ruff="py313", pyright="3.13"),
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["python-version-agreement"] == "ok"
+    assert "4 declaration(s)" in flat(proc.stdout)
+
+
+def test_rule_10_fires_when_a_tool_holds_a_level_the_floor_does_not(repo: Path) -> None:
+    write(
+        repo,
+        "pyproject.toml",
+        pyproject_python(floor=">=3.13", pin="3.13.*", ruff="py312", pyright="3.13"),
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["python-version-agreement"] == "FAIL"
+    assert (
+        "[tool.ruff] target-version `py312` says 3.12, and [project] requires-python `>=3.13` "
+        "says 3.13" in proc.stderr
+    )
+    # Named the site, what it says, and what it should say instead.
+    assert 'write `target-version = "py313"`' in flat(proc.stderr)
+
+
+def test_rule_10_fires_on_a_pin_below_the_floor(repo: Path) -> None:
+    # The other direction: the repo runs an interpreter its own metadata refuses to install on.
+    write(repo, "pyproject.toml", pyproject_python(floor=">=3.13", pin="3.12.*"))
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["python-version-agreement"] == "FAIL"
+    assert (
+        "[tool.pixi.dependencies] python `3.12.*` pins 3.12, below the [project] requires-python "
+        "floor `>=3.13`" in proc.stderr
+    )
+
+
+def test_rule_10_measures_a_tool_against_the_pin_when_there_is_no_floor(repo: Path) -> None:
+    write(repo, "pyproject.toml", pyproject_python(pin="3.13.*", ruff="py312"))
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["python-version-agreement"] == "FAIL"
+    assert "[tool.pixi.dependencies] python `3.13.*` says 3.13" in proc.stderr
+
+
+def test_rule_10_passes_a_range_that_pixi_actually_resolves(repo: Path) -> None:
+    # The case the rule exists to leave alone: a repo supporting 3.10 through 3.13 on purpose. The
+    # floor is below the default pin, the tools are held to the floor, and a feature gives 3.10 an
+    # environment — so the range is a claim pixi resolves rather than one nothing exercises.
+    write(
+        repo,
+        "pyproject.toml",
+        pyproject_python(
+            floor=">=3.10", pin="3.13.*", feature_pin="3.10.*", ruff="py310", pyright="3.10"
+        ),
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["python-version-agreement"] == "ok"
+    assert "the floor 3.10 is itself pinned, so pixi resolves it" in flat(proc.stdout)
+
+
+def test_rule_10_says_it_cannot_tell_a_range_from_a_floor_nobody_lowered(repo: Path) -> None:
+    # Copied from a real Liu Lab repo, which carried exactly this: a >=3.12 floor, a 3.13 pin,
+    # ruff and pyright at 3.12, and a lockfile holding only 3.13. The declarations AGREE — the
+    # tools are at the floor, which is what a deliberate range looks like — so the rule does not
+    # fail it. What it must not do is call that a clean pass in silence: nothing pins 3.12, so the
+    # promise of 3.12 support is exercised by nothing, and the notes say so on every run.
+    write(
+        repo,
+        "pyproject.toml",
+        pyproject_python(floor=">=3.12", pin="3.13.*", ruff="py312", pyright="3.12"),
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["python-version-agreement"] == "ok"
+    printed = flat(proc.stdout)
+    # Every site and what each one says, so the split is readable at a glance.
+    for said in (
+        "[project] requires-python `>=3.12`",
+        "[tool.pixi.dependencies] python `3.13.*`",
+        "[tool.ruff] target-version `py312`",
+        "[tool.pyright] pythonVersion `3.12`",
+    ):
+        assert said in printed
+    assert "not checked: whether 3.12 is ever resolved or tested" in printed

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -7,8 +7,8 @@ checked by no rule at all, with zero alerts and green CI. So the claim these tes
 
 Every test builds a tmp_path tree that is correct in every respect but one, and asserts the run
 marks THAT rule FAIL and names the offending file. The rule name alone would prove nothing: the
-status table prints all twelve names on every run, passing or failing, so the assertions read the
-status word out of the table rather than grepping the output for a name.
+status table prints all thirteen names on every run, passing or failing, so the assertions read
+the status word out of the table rather than grepping the output for a name.
 
 Conformance is invoked as a SUBPROCESS, so what is under test is the command an agent runs and
 CI runs, not an internal function that could be refactored into something the command no longer
@@ -39,6 +39,10 @@ FRONT_MATTER = "---\nsearch:\n  exclude: true\n---\n\n"
 PYPROJECT = """\
 [project]
 name = "example"
+
+[tool.pixi.tasks]
+build = "python -m build"
+test = "pytest"
 
 [tool.liulab.agent-docs]
 "AGENTS.md" = "LengthDoc"
@@ -111,6 +115,8 @@ def publishes(root: Path, on: str) -> None:
 
     The body is a real job with real steps, not a bare `on:` block: the accessor the rule reads
     parses the whole file, and a fixture that carried triggers alone would never exercise that.
+    Its one command invokes `build`, which `PYPROJECT` declares, so rule 11 stays green here and
+    rule 9 is the only thing these trees vary.
     """
     write(
         root,
@@ -126,6 +132,25 @@ def publishes(root: Path, on: str) -> None:
     write(root, "CHANGELOG.md", "# Changelog\n\nNothing yet.\n")
 
 
+def runs(root: Path, *commands: str, job: str = "check") -> None:
+    """A `ci.yml` whose one job checks out an action and then runs each command given.
+
+    Not `release.yml`: that path is rule 9's premise and rule 8's, and a rule 11 fixture must vary
+    nothing but the commands. The leading `uses:` step is in every tree here on purpose — it is
+    what proves an action step is passed over rather than merely absent.
+    """
+    steps = "".join(f"      - run: {command}\n" for command in commands)
+    write(
+        root,
+        ".github/workflows/ci.yml",
+        "name: ci\non:\n  pull_request:\njobs:\n"
+        f"  {job}:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7\n" + steps,
+    )
+
+
 def add_skill(root: Path, name: str) -> None:
     """A skill and both committed discovery symlinks, relative, as `install.py` writes them."""
     write(root, f"skills/{name}/SKILL.md", f"---\nname: {name}\n---\n\n# {name}\n")
@@ -139,10 +164,10 @@ def add_skill(root: Path, name: str) -> None:
 def repo(tmp_path: Path) -> Path:
     """A tree that passes every rule, for one test to break in exactly one way.
 
-    It has no `src/` and no release workflow, so rule 8's two conditionals and rule 9 are all
-    vacuous here; the tests that care add the premise, rule 9's through `publishes`. It has no
-    `skills/init-repo/`, so rule 1 and warning 11 are both live — the state a derived repo is in,
-    and the only state where they check anything.
+    It has no `src/`, no workflow at all and so no release workflow, so rule 8's two conditionals,
+    rule 9 and rule 11 are all vacuous here; the tests that care add the premise, through
+    `publishes` and `runs`. It has no `skills/init-repo/`, so rule 1 and warning 12 are both live
+    — the state a derived repo is in, and the only state where they check anything.
     """
     root = tmp_path / "repo"
     write(root, "pyproject.toml", PYPROJECT)
@@ -183,8 +208,8 @@ def statuses(proc: subprocess.CompletedProcess[str]) -> dict[str, str]:
     """The verdict the run gave each rule, read off its own status table.
 
     Asserting on the status word rather than on the presence of a rule NAME is the point: the
-    table prints all twelve names on every run, so `"repo-shape" in output` is true of a green run
-    and would prove nothing at all.
+    table prints all thirteen names on every run, so `"repo-shape" in output` is true of a green
+    run and would prove nothing at all.
     """
     found: dict[str, str] = {}
     for line in proc.stdout.splitlines():
@@ -213,8 +238,9 @@ def test_the_fixture_tree_passes_every_rule(repo: Path) -> None:
         "skill-symlinks",
         "repo-shape",
         "release-trigger",
-        "init-sentinel",
         "single-toolchain",
+        "workflow-step-tasks",
+        "init-sentinel",
         "waivers",
     }
     assert verdicts["placeholder-rename"] == "ok"  # live, not gated off
@@ -276,7 +302,7 @@ def test_rule_1_refuses_to_be_waived(repo: Path) -> None:
     assert proc.returncode == 1
     assert statuses(proc)["placeholder-rename"] == "FAIL"
     assert "cannot be waived" in proc.stderr
-    assert "REFUSED" in proc.stdout  # and warning 12 still prints it
+    assert "REFUSED" in proc.stdout  # and warning 13 still prints it
 
 
 def test_rule_2_fires_on_a_page_that_is_not_excluded_from_search(repo: Path) -> None:
@@ -489,7 +515,7 @@ def test_rule_9_is_vacuous_and_not_passing_when_the_repo_publishes_nothing(repo:
     )
 
 
-def test_warning_10_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> None:
+def test_warning_12_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> None:
     write(
         repo,
         "AGENTS.md",
@@ -501,7 +527,7 @@ def test_warning_10_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> No
     assert "AGENTS.md still carries the `/init` sentinel" in flat(proc.stdout)
 
 
-def test_warning_10_is_silent_while_the_init_skill_is_the_nag(repo: Path) -> None:
+def test_warning_12_is_silent_while_the_init_skill_is_the_nag(repo: Path) -> None:
     write(
         repo,
         "AGENTS.md",
@@ -522,7 +548,7 @@ def test_a_waiver_suppresses_its_rule_and_is_still_printed(repo: Path) -> None:
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert statuses(proc)["glossary-entry-length"] == "waived"
     assert f"1 problem(s) suppressed: {reason}" in flat(proc.stdout)
-    # and warning 12 prints it a second time, in the waiver table
+    # and warning 13 prints it a second time, in the waiver table
     assert f"glossary-entry-length: 1 problem(s) suppressed — {reason}" in flat(proc.stdout)
 
 
@@ -555,7 +581,7 @@ def test_every_failure_is_reported_and_not_just_the_first(repo: Path) -> None:
     assert verdicts["agent-docs-unpublished"] == "FAIL"
     assert verdicts["skill-file-location"] == "FAIL"
     assert verdicts["repo-shape"] == "FAIL"
-    assert "3 of 10 rules failed" in proc.stderr
+    assert "3 of 11 rules failed" in proc.stderr
 
 
 def test_rule_10_fires_on_a_pre_commit_configuration(repo: Path) -> None:
@@ -622,3 +648,186 @@ def test_rule_10_says_which_second_toolchains_it_looked_for(repo: Path) -> None:
     assert statuses(proc)["single-toolchain"] == "ok"
     assert "8 second toolchain(s) looked for" in flat(proc.stdout)
     assert "pre-commit, pip, conda, pipenv, setuptools, poetry, uv, pdm" in flat(proc.stdout)
+
+
+def test_rule_11_fires_on_a_step_that_runs_a_bare_command(repo: Path) -> None:
+    runs(repo, "pytest -q")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    assert (
+        ".github/workflows/ci.yml job `check` step 1 runs a command rather than `pixi run <task>`"
+        in proc.stderr
+    )
+    assert "declare what it runs as a task in [tool.pixi.tasks]" in flat(proc.stderr)
+
+
+def test_rule_11_passes_a_step_that_invokes_a_declared_task(repo: Path) -> None:
+    # Two spellings, because the template writes both: a plain task, and one reached through an
+    # environment flag. A rule that read `pixi run <word>` and stopped would fail the second.
+    runs(repo, "pixi run build", "pixi run -e test test")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "ok"
+    # The anti-vacuity assertion. A rule handed no steps passes every workflow ever written, so
+    # the green above means something only once the run says how many steps it read.
+    assert "2 step(s) that run a command, across 1 workflow(s), against 2 declared task(s)" in flat(
+        proc.stdout
+    )
+
+
+def test_rule_11_reads_past_the_environment_flag_to_the_task(repo: Path) -> None:
+    # `test` is BOTH an environment and a declared task here, which is the trap: a rule that
+    # accepted any declared name among the tokens would call this green and let the inlined
+    # `pytest` through — the exact drift the rule exists to catch, hidden behind a `-e`.
+    runs(repo, "pixi run -e test pytest")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    assert "step 1 invokes `pytest`, which this repo declares no task by" in proc.stderr
+
+
+def test_rule_11_fires_on_a_task_nobody_declared(repo: Path) -> None:
+    # Not an inlined command: it follows the convention exactly and names a task that does not
+    # exist. Nothing runs it until the workflow does, and this one is `ci.yml`; on `release.yml`
+    # the first run is the release.
+    runs(repo, "pixi run typecheck")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    assert "invokes `typecheck`, which this repo declares no task by" in proc.stderr
+    assert "declare `typecheck` in pyproject.toml under [tool.pixi.tasks]" in flat(proc.stderr)
+
+
+def test_rule_11_finds_a_task_declared_on_a_feature(repo: Path) -> None:
+    # `docs-build` is on the `docs` FEATURE in the real manifest, not on the workspace. A rule
+    # reading `[tool.pixi.tasks]` alone would fail the docs job of a workflow that is correct.
+    write(
+        repo, "pyproject.toml", PYPROJECT + '\n[tool.pixi.feature.docs.tasks]\ndocs-build = "z"\n'
+    )
+    runs(repo, "pixi run docs-build")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "ok"
+    assert "against 3 declared task(s)" in flat(proc.stdout)
+
+
+def test_rule_11_does_not_flag_a_step_that_uses_an_action(repo: Path) -> None:
+    # Three `uses:` steps, one of them carrying a command line in its `with:` block. An action is
+    # a dependency the workflow pulls in, not a step of this repo's build, so none of them is a
+    # task that went missing — and the count in the note is what proves they were passed over
+    # rather than merely absent.
+    write(
+        repo,
+        ".github/workflows/ci.yml",
+        "name: ci\non:\n  pull_request:\njobs:\n"
+        "  check:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7\n"
+        "      - uses: prefix-dev/setup-pixi@v0.10.2\n"
+        "        with:\n"
+        "          environments: default\n"
+        "      - run: pixi run build\n"
+        "      - uses: actions/upload-artifact@v7\n"
+        "        with:\n"
+        "          args: rm -rf dist\n",
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "ok"
+    assert "1 step(s) that run a command" in flat(proc.stdout)
+
+
+def test_rule_11_fires_on_a_command_chained_onto_a_task(repo: Path) -> None:
+    # It does invoke a declared task. What follows the task is the same drift one level down: a
+    # laptop running `pixi run build` never deletes anything.
+    runs(repo, "pixi run build && rm -rf dist")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    assert "step 1 runs a command rather than `pixi run <task>`" in proc.stderr
+
+
+def test_rule_11_fires_on_a_multi_line_script(repo: Path) -> None:
+    write(
+        repo,
+        ".github/workflows/ci.yml",
+        "name: ci\non:\n  pull_request:\njobs:\n"
+        "  check:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: Everything at once\n"
+        "        run: |\n"
+        "          pixi run build\n"
+        "          pixi run -e test test\n",
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    # Named, because this step has a `name:` and a reader should not have to count steps.
+    assert "step 0 (Everything at once) runs a command" in proc.stderr
+
+
+def test_rule_11_reports_a_task_named_by_an_expression_as_unresolved(repo: Path) -> None:
+    # A matrix over tasks. GitHub substitutes the expression when the job runs, so the second step
+    # names a task this cannot look up — reported, not failed, since a rule that cannot evaluate
+    # its premise has checked nothing. The first step shows an expression somewhere OTHER than the
+    # task name is resolved past and not counted.
+    runs(repo, "pixi run -e ${{ matrix.environment }} test", "pixi run ${{ matrix.task }}")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "ok"
+    assert "2 step(s) that run a command" in flat(proc.stdout)
+    assert "1 step(s) name their task with a `${{}}` expression" in flat(proc.stdout)
+
+
+def test_rule_11_is_vacuous_and_not_passing_when_no_workflow_runs_a_command(repo: Path) -> None:
+    # A repo whose workflows are all actions, or that has none at all. Nothing was checked, and a
+    # green here would read as "every step invokes a task", which this run has no evidence for.
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "--"
+    assert "not checked: no tracked workflow has a step that runs a command" in flat(proc.stdout)
+
+
+def test_the_workflow_reader_flattens_every_job_and_not_just_the_first(repo: Path) -> None:
+    # The step the rule must find is the LAST step of the SECOND job. A reader that stopped at the
+    # first job, or at a job's first step, would call this tree green.
+    write(
+        repo,
+        ".github/workflows/ci.yml",
+        "name: ci\non:\n  pull_request:\njobs:\n"
+        "  check:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7\n"
+        "      - run: pixi run build\n"
+        "  test:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7\n"
+        "      - run: pixi run -e test test\n"
+        "      - run: coverage report\n",
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    assert ".github/workflows/ci.yml job `test` step 2 runs a command" in proc.stderr
+    # One problem and not three: the other two steps of the two jobs were read and were fine.
+    assert "workflow-step-tasks FAIL 1 problem(s)" in flat(proc.stdout)
+
+
+def test_a_workflow_that_will_not_parse_is_read_as_empty_and_not_as_an_exception(
+    repo: Path,
+) -> None:
+    # A derived repo's unusual workflow must not turn a conformance rule into a crash. The file
+    # counts as a workflow and contributes no steps, so the rules that read workflows keep
+    # reporting on the ones they could read.
+    write(repo, ".github/workflows/broken.yml", "name: broken\non: [\njobs: }{\n")
+    runs(repo, "pixi run build")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "ok"
+    assert "1 step(s) that run a command, across 2 workflow(s)" in flat(proc.stdout)

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -7,7 +7,7 @@ checked by no rule at all, with zero alerts and green CI. So the claim these tes
 
 Every test builds a tmp_path tree that is correct in every respect but one, and asserts the run
 marks THAT rule FAIL and names the offending file. The rule name alone would prove nothing: the
-status table prints all ten names on every run, passing or failing, so the assertions read the
+status table prints all eleven names on every run, passing or failing, so the assertions read the
 status word out of the table rather than grepping the output for a name.
 
 Conformance is invoked as a SUBPROCESS, so what is under test is the command an agent runs and
@@ -88,6 +88,11 @@ nav:
       - API: api.md
 """
 
+# The publishing workflow, spelled out here rather than imported from the checker: a test that
+# borrowed the path would agree with rule 9 by construction and prove nothing about the
+# convention. Rule 8 wants a CHANGELOG.md wherever this file is, so `publishes` writes both.
+RELEASE_YML = ".github/workflows/release.yml"
+
 _STATUS_RE = re.compile(
     r"^\s+(?:rule|warn) \d+\s+(?P<name>\S+)\s+(?P<status>ok|FAIL|--|warn|waived)(\s|$)"
 )
@@ -99,6 +104,26 @@ def write(root: Path, rel: str, text: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
     return path
+
+
+def publishes(root: Path, on: str) -> None:
+    """Give the tree a publishing workflow with one `on:` block, and the changelog rule 8 wants.
+
+    The body is a real job with real steps, not a bare `on:` block: the accessor the rule reads
+    parses the whole file, and a fixture that carried triggers alone would never exercise that.
+    """
+    write(
+        root,
+        RELEASE_YML,
+        f"name: release\n{on}"
+        "jobs:\n"
+        "  build:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7\n"
+        "      - run: pixi run build\n",
+    )
+    write(root, "CHANGELOG.md", "# Changelog\n\nNothing yet.\n")
 
 
 def add_skill(root: Path, name: str) -> None:
@@ -114,9 +139,10 @@ def add_skill(root: Path, name: str) -> None:
 def repo(tmp_path: Path) -> Path:
     """A tree that passes every rule, for one test to break in exactly one way.
 
-    It has no `src/` and no release workflow, so rule 8's two conditionals are both vacuous here;
-    the tests that care add the premise. It has no `skills/init-repo/`, so rule 1 and warning 9
-    are both live — the state a derived repo is in, and the only state where they check anything.
+    It has no `src/` and no release workflow, so rule 8's two conditionals and rule 9 are all
+    vacuous here; the tests that care add the premise, rule 9's through `publishes`. It has no
+    `skills/init-repo/`, so rule 1 and warning 10 are both live — the state a derived repo is in,
+    and the only state where they check anything.
     """
     root = tmp_path / "repo"
     write(root, "pyproject.toml", PYPROJECT)
@@ -186,6 +212,7 @@ def test_the_fixture_tree_passes_every_rule(repo: Path) -> None:
         "skill-name-prefix",
         "skill-symlinks",
         "repo-shape",
+        "release-trigger",
         "init-sentinel",
         "waivers",
     }
@@ -228,7 +255,7 @@ def test_rule_1_fires_on_a_placeholder_in_a_path_not_only_in_a_file(repo: Path) 
 
 def test_rule_1_is_not_checked_while_the_init_skill_is_there(repo: Path) -> None:
     # The template ships the placeholder ON PURPOSE, and `skills/init-repo/` is what says the
-    # rename has not happened yet. Same discriminator warning 9 uses.
+    # rename has not happened yet. Same discriminator warning 10 uses.
     write(repo, "README.md", f"# liulab-{PLACEHOLDER}\n\nStill the template.\n")
     add_skill(repo, "init-repo")
     proc = conformance(repo)
@@ -401,7 +428,67 @@ def test_rule_8_is_satisfied_and_not_merely_skipped_when_both_premises_hold(repo
     assert statuses(proc)["repo-shape"] == "ok"
 
 
-def test_warning_9_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> None:
+def test_rule_9_fires_on_a_publishing_workflow_triggered_by_a_tag_push(repo: Path) -> None:
+    publishes(repo, "on:\n  push:\n    tags: ['v*']\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["release-trigger"] == "FAIL"
+    assert f"{RELEASE_YML} can be triggered by a tag push: `on: push:` names `tags:`" in proc.stderr
+    assert "cannot be undone" in flat(proc.stderr)  # the rule and the fix, not a rewritten assert
+    assert "trigger it on `release:` with `types: [published]`" in flat(proc.stderr)
+
+
+def test_rule_9_fires_on_a_push_with_no_branch_filter(repo: Path) -> None:
+    # The hole a rule written only for `tags:` would leave wide open. An absent filter is not
+    # "no refs" — GitHub reads it as every ref, so this fires on `v0.0.0` like any other.
+    publishes(repo, "on:\n  push:\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["release-trigger"] == "FAIL"
+    assert "`on: push:` names no branch filter, so it fires on every ref, tags too" in proc.stderr
+
+
+def test_rule_9_fires_on_create_which_a_pushed_tag_also_fires(repo: Path) -> None:
+    publishes(repo, "on:\n  create:\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["release-trigger"] == "FAIL"
+    assert "`on: create:` fires when a tag comes into existence" in proc.stderr
+
+
+def test_rule_9_passes_a_workflow_triggered_by_a_published_release(repo: Path) -> None:
+    publishes(repo, "on:\n  release:\n    types: [published]\n  workflow_dispatch:\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["release-trigger"] == "ok"
+    # The note is the anti-vacuity assertion, and it is the only one here that matters. YAML 1.1
+    # resolves an unquoted `on` to the boolean true, so an accessor reading `document["on"]` finds
+    # no triggers at all — and a rule handed no triggers passes every workflow ever written.
+    assert f"{RELEASE_YML} is triggered by release, workflow_dispatch" in flat(proc.stdout)
+
+
+def test_rule_9_allows_a_push_that_names_branches(repo: Path) -> None:
+    # Naming any branch filter is what stops tags reaching a workflow, so this one is a branch
+    # trigger and not a violation. A rule that failed every `push:` would fail `ci.yml` too.
+    publishes(repo, "on:\n  push:\n    branches: [main]\n  release:\n    types: [published]\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["release-trigger"] == "ok"
+
+
+def test_rule_9_is_vacuous_and_not_passing_when_the_repo_publishes_nothing(repo: Path) -> None:
+    # `init-repo` deletes the workflow for a repo that does not publish. Nothing was checked, and
+    # the run has to say so: a green here would read as "the trigger is safe", which is a claim
+    # this run has no evidence for.
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["release-trigger"] == "--"
+    assert f"not checked: no {RELEASE_YML}, so this repo publishes to no package index" in flat(
+        proc.stdout
+    )
+
+
+def test_warning_10_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> None:
     write(
         repo,
         "AGENTS.md",
@@ -413,7 +500,7 @@ def test_warning_9_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> Non
     assert "AGENTS.md still carries the `/init` sentinel" in flat(proc.stdout)
 
 
-def test_warning_9_is_silent_while_the_init_skill_is_the_nag(repo: Path) -> None:
+def test_warning_10_is_silent_while_the_init_skill_is_the_nag(repo: Path) -> None:
     write(
         repo,
         "AGENTS.md",
@@ -467,4 +554,4 @@ def test_every_failure_is_reported_and_not_just_the_first(repo: Path) -> None:
     assert verdicts["agent-docs-unpublished"] == "FAIL"
     assert verdicts["skill-file-location"] == "FAIL"
     assert verdicts["repo-shape"] == "FAIL"
-    assert "3 of 8 rules failed" in proc.stderr
+    assert "3 of 9 rules failed" in proc.stderr


### PR DESCRIPTION
Seven issues, one branch, an agent per issue. Every commit is its own issue's work; the merge
commits carry the integration decisions and say what went wrong in them.

## What lands

| Issue | Change |
| --- | --- |
| #43 | Conformance reads workflow definitions at all — a `Workflow`/`Step` accessor — and fails a publishing workflow a tag push can trigger |
| #44 | Fails a workflow step that runs a bare command instead of invoking a declared task |
| #45 | Holds every declared Python version to the floor and the pin — agreement, never a count |
| #46 | Fails a repo that grew a second dependency toolchain, covering the class rather than one tool |
| #47 | The gate runner stops burying failures and stops outliving Ctrl-C |
| #49 | Docstring examples run as tests, so an example that drifts from its code fails |
| #51 | Records what a strict docs build does and does not catch, and turns on what the generator offers |

Conformance goes from ten rules to fourteen: twelve that fail, two that warn.

## The principle that shaped it

The template is general, lightweight and generalizable. A downstream repo may customize itself
however it likes; none of that flows back here. Three issues were closed rather than built
because they were downstream needs pointed at a shared checker — #42 (teaching the glossary rule
one repo's document idiom), #48 (machinery the template has no external binaries to demonstrate),
#50 (a writing convention, over records `init-repo` deletes anyway).

The same principle changed two of the rules that did land. #45 checks that Python declarations
**agree** rather than counting them: an earlier draft required "exactly two places", which would
fail any repo legitimately supporting a version range and make this template unusable for a
library. #46 covers the class of second toolchains with the marker list in one place, rather than
naming the one tool a downstream repo happened to have.

## Verification

`pixi run check` green (6 static steps, 65 tests). `pixi run docs-build` green. `pixi run dogfood`
green — all three rendered shapes pass their own gate with the four new rules live.

Two things were verified rather than asserted:

- **#47's interrupt fix** was proved against the *old* script under the same harness: 6 surviving
  worker processes before, 0 after, capture directory cleaned. The real cause is that a
  non-interactive shell without job control sets SIGINT to ignore on background children — which
  is the mode CI runs in.
- **#51's catches/misses table** was built and observed row by row against the pinned generator.
  It found that a `nav:` entry naming a missing file is **not caught at all**: "No issues found",
  exit 0, dead href shipped. No setting exists for it, and the two mkdocs keys that would have are
  dropped in silence. Filed as #53, since documenting it does not close the CI hole.

## Integration notes worth reading

Four rules landed on one file from four branches, so the merges were the risky part, not the code.

- Git fused two `Rule(...)` entries into one, because the constructor and its number were common
  context while the bodies conflicted. It produces a syntactically valid entry with two names.
- Twice, a rule function lost its trailing `return result` for the same reason — the shared line
  attaches to whichever function ends up last. Both times pyright caught it and conformance
  crashed on a rule returning `None`. Every rule is now checked to *end* in a return.
- Two branches named their tests `test_rule_11_*`. Duplicate test names do not collide loudly:
  the later definition shadows the earlier and the suite silently stops running it. Renamed, and
  the module is checked for shadowing.
- #45 and #46 both added an accessor parsing the manifest under different names; kept one.

## Follow-ups filed, not built

- **#52** — pyright's `standard` mode does not check parameter annotations at all. Measured:
  `basic` and `standard` both give 0 errors on `def f(x): return x`; only `strict` catches it.
  Naming the two rules costs this tree nothing today.
- **#53** — the nav hole above, which belongs in conformance rather than in site config.

Closes #43, closes #44, closes #45, closes #46, closes #47, closes #49, closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZNsHzTC77n87dtoGiN581
