### PR TITLE
Six follow-ups: an annotation rule declined, a nav gate, an exit-code contract, and two writing rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # A real checkout, not a source archive: `conformance` shells out to `git ls-files`
-      # and exits 2 without a `.git`. The default shallow depth is enough — it needs the
-      # file list, not the history.
+      # and exits 2 without a `.git` — its "could not run", spelled apart from the 1 a
+      # broken rule exits, so a bad checkout never reads as a rule this repo failed. The
+      # default shallow depth is enough — it needs the file list, not the history.
       - uses: actions/checkout@v7
       - uses: prefix-dev/setup-pixi@v0.10.2
         with:

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -22,3 +22,9 @@ config:
   # matter of taste, and tables and long links routinely exceed any limit, so MD013 would
   # fire on every one of them.
   MD013: false
+  # Scoped, not disabled. A Keep a Changelog file gives every release the same section
+  # names, so `### Added` recurs once per release by design and the default fails a
+  # correct changelog on its SECOND release. `siblings_only` still fails one release
+  # repeating its own section, which is the duplicate that is a real mistake.
+  MD024:
+    siblings_only: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ CONTEXT.md        the glossary — the words this repo uses
 | Step | Tool |
 | --- | --- |
 | `lint`, `fmt-check` | ruff |
-| `typecheck` | pyright, `standard` mode |
+| `typecheck` | pyright, `standard` mode, plus annotated parameters |
 | `vale`, `markdownlint` | the writing rules |
 | `conformance` | the repo still matches the template's rules |
 | `test` | pytest |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,8 @@ sets one.
   ships switched off, and a comment beside it listing, from measurement, which broken links
   a strict build catches and which three it lets through. A `nav:` entry naming a file that
   is not there is one of the three, and no setting catches it.
+- A conformance rule that fails a `nav:` entry naming a file the repo does not track, or one
+  that sits outside the site source. That is the broken site the builder does not validate
+  at all — it reports no issues, exits 0, and publishes a menu item that 404s — so the check
+  had to go somewhere it could be one. It reads every site config, so a repo building more
+  than one site from one docs tree has both navs checked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,8 @@ sets one.
   ships switched off, and a comment beside it listing, from measurement, which broken links
   a strict build catches and which three it lets through. A `nav:` entry naming a file that
   is not there is one of the three, and no setting catches it.
+- `reportMissingParameterType` beside the pyright mode, because `standard` does not check
+  that a parameter is annotated at all — the bar was kept by discipline and nothing would
+  have noticed a repo dropping it. Its sibling `reportUnknownParameterType` was considered
+  and declined: it also fails parameters that *are* annotated when the type belongs to an
+  untyped dependency, which is not a bar a lab repo can hold.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,11 @@ sets one.
   at all — it reports no issues, exits 0, and publishes a menu item that 404s — so the check
   had to go somewhere it could be one. It reads every site config, so a repo building more
   than one site from one docs tree has both navs checked.
+
+### Changed
+
+- `conformance` now exits 2 when it could not run at all: no `.git`, no `pyproject.toml`, or
+  a `pyproject.toml` it cannot read. It still exits 1 when it ran and a rule failed, and 0
+  when every rule passed. Both used to exit 1, so a bad checkout looked just like a repo that
+  broke a rule. The two want opposite answers: one is a repo to fix, the other is a repo that
+  nothing checked. `scripts/check.sh` already used 2 that way.

--- a/docs/adr/0001-docs-site-on-zensical.md
+++ b/docs/adr/0001-docs-site-on-zensical.md
@@ -30,11 +30,12 @@ Three gaps, each with a named workaround:
   front matter, and `mkdocs.yml` carries an explicit `nav:`. Front matter does nothing
   about the navbar; `nav:` does nothing about search. Both, always.
 - **`--strict` validates links, not the `nav:`.** A nav entry naming a missing file failed
-  a strict mkdocs build and passes this one, and no setting turns that back on. Dead links
-  and dead anchors still fail, so `--strict` is worth passing. The measured list of what it
-  catches and misses is a comment in `mkdocs.yml`, beside the `nav:` a maintainer edits and
-  the settings it turns on — this record is deleted from a repo made from the template, and
-  the gap is not.
+  a strict mkdocs build and passes this one, and no setting turns that back on. Conformance
+  rule `nav-target-exists` fails it instead: a setting that cannot be shown to be honoured
+  is not a gate, so the check went where it can be one. Dead links and dead anchors still
+  fail, so `--strict` is worth passing. The measured list of what it catches and misses is a
+  comment in `mkdocs.yml`, beside the `nav:` a maintainer edits and the settings it turns
+  on — this record is deleted from a repo made from the template, and the gap is not.
 
 The research note expected one residue — excluded pages still listed in `sitemap.xml`. With
 an explicit `nav:` that does not happen: zensical builds the sitemap from the nav, so the

--- a/docs/agents/writing.md
+++ b/docs/agents/writing.md
@@ -34,6 +34,13 @@ document ran long; that is the cap working.
 (`Lab.Jargon` — architecture-speak and Latinate verbs), and reading grade 11 or below
 (`Lab.Readability`). No length cap — a tutorial is as long as the task.
 
+**When `Lab.Readability` fails, match a passing exemplar — do not attack the number.** The
+grade is a ratio over structure, so shaving words inside sentences you already committed to
+moves it by hundredths. Find text that passes — an older section, a sibling page — and rewrite
+toward how it is segmented. Measured on a 21,000-word changelog: optimising the grade directly
+moved it 12.46 to 12.41; matching a passing section in the same file moved it under 11, while
+cutting only 3% of the words and *raising* the entry count.
+
 **This rule also covers what you say, not only what you write.** Nothing checks a chat
 reply, so it is on you: when a human asks, answer in plain language and explain the term
 you would otherwise reach for. An unexplained term in conversation is the same failure as

--- a/docs/agents/writing.md
+++ b/docs/agents/writing.md
@@ -24,6 +24,12 @@ survives deletion without loss, delete it. The caps below are ceilings, not targ
 `conformance`, not by vale. A glossary grows one term at a time, so the file is the wrong
 unit to measure.
 
+**Measure with the gate, not with `wc`.** `wc -w` counts table pipes, link targets and
+shell flags as words; vale does not, and vale is what enforces the cap. The gap scales with
+markup — measured across this repo it runs from 10% on prose to 65% on a page that is mostly
+a table, so `wc` will tell you a reference page is near a cap it is nowhere near. Run
+`pixi run vale` and believe it.
+
 The caps are dials with tight defaults. Raising one is a one-line diff in `styles/Lab/` —
 do that deliberately, and say why in the commit message. Do not raise a cap because a
 document ran long; that is the cap working.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,10 +18,10 @@ site_description: "One line: what this repo is for. `init-repo` rewrites this."
 # `search: exclude: true` front matter on those pages is for. Neither mechanism
 # substitutes for the other, and `exclude_docs:` is silently ignored, so both are needed.
 #
-# Add a human-facing page here when you write one, and CHECK THE FILE IS THERE — a nav
-# entry naming a missing file builds green and publishes a menu item that 404s. Never add a
-# page under docs/adr/, docs/agents/ or docs/research/: conformance rule 2 fails the build
-# if you do.
+# Add a human-facing page here when you write one. A nav entry naming a missing file builds
+# green and publishes a menu item that 404s, so conformance rule `nav-target-exists` fails
+# it instead. Never add a page under docs/adr/, docs/agents/ or docs/research/: conformance
+# rule `agent-docs-unpublished` fails the build if you do.
 nav:
   - Home: index.md
   - API reference: api.md
@@ -38,9 +38,11 @@ nav:
 #
 # Nothing below fixes the three MISSED rows and no setting does: zensical validates links
 # and not the nav, and it drops mkdocs' `absolute_links:` and `unrecognized_links:` keys in
-# silence, so writing them in would look like a check and be none. Read those three rows as
-# work for a human. Row three needs the mkdocstrings plugin, so a repo without one is down
-# to two.
+# silence, so writing them in would look like a check and be none. The nav row is caught by
+# conformance rule `nav-target-exists` instead, which fails a nav entry naming a file this
+# repo does not track — a setting nothing can be shown to honour is not a gate, so the check
+# went where it can be. Read the other two MISSED rows as work for a human. The third CAUGHT
+# row needs the mkdocstrings plugin, so a repo without one is down to two.
 #
 # `not_found:` and `anchors:` are zensical's defaults, spelled out because they are the two
 # keys mkdocs also understands. The five under them are zensical's own and mkdocs rejects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,11 @@ venvPath = ".pixi/envs"
 venv = "default"
 # No `pythonVersion`: taken from the interpreter in the environment above.
 typeCheckingMode = "standard"
+# Not redundant: `standard` does not check that a parameter is annotated at all. `Any`
+# satisfies it, so the fix is always in the file you are editing.
+reportMissingParameterType = "error"
+# Deliberately NOT `reportUnknownParameterType`: it also fails annotated parameters and
+# inferred return types whose types an untyped dependency owns. Not a bar a lab repo can meet.
 useLibraryCodeForTypes = true
 reportMissingTypeStubs = "none"
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -13,6 +13,12 @@
 # everything. A red run is read to find the failure, and the full output of every
 # green step is thousands of lines of nothing standing between the reader and it.
 #
+# Exit status: 1 when a step ran and failed, 2 when the gate itself could not run —
+# a usage error, or a capture directory it could not make. `scripts/conformance.py`,
+# the one step this repo writes rather than installs, spells its own two the same way,
+# and the summary prints each step's own status, so "could not run" reaches the reader
+# as itself rather than as a rule nobody broke.
+#
 # The step list lives in the `check-static` task in pyproject.toml and nowhere else,
 # so adding a step is one more word in one place and the local gate cannot drift
 # from CI, which invokes the same task names.

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -5,7 +5,7 @@
     python scripts/conformance.py [--root PATH]
 
 It states the RULE, not the file contents — a pull model, so a repo that legitimately diverges
-stays green while the shared conventions stay checked. Fourteen rules: twelve fail, two only warn.
+stays green while the shared conventions stay checked. Fifteen rules: thirteen fail, two only warn.
 
 Three things it does on purpose:
 
@@ -56,7 +56,7 @@ import yaml
 #: neither happens.
 PLACEHOLDER = "new" + "pkg"
 
-#: Rule 1 and warning 12 are both gated on this directory, and it is the only discriminator either
+#: Rule 1 and warning 14 are both gated on this directory, and it is the only discriminator either
 #: needs. While it is here, `init-repo` has not run: the placeholder is still the repo's own name,
 #: and the auto-discovered skill is itself the nag. Once it is gone the repo claims to be its own,
 #: and both rules start checking.
@@ -65,9 +65,20 @@ INIT_SKILL = "skills/init-repo"
 #: Rule 1's name, needed by name because it is the one rule that refuses to be waived.
 UNWAIVABLE = "placeholder-rename"
 
-#: Where `mkdocs.yml` puts the site source when it does not say. Rule 2 is scoped to the pages the
-#: site publishes, so it reads this rather than assuming.
+#: The site configuration every repo that publishes a site has, and where the site source sits
+#: when it does not say. Rules 2 and 13 are both scoped to the pages the site publishes, so they
+#: read the declared source rather than assuming it.
+SITE_CONFIG = "mkdocs.yml"
 DEFAULT_DOCS_DIR = "docs"
+
+#: A site configuration AT THE REPO ROOT, `mkdocs.yml` and any variant beside it. Root-anchored,
+#: so an example config under `docs/` is a document and not a configuration.
+#:
+#: Rule 13 reads every one of them, not only `SITE_CONFIG`, because a repo may build more than one
+#: site from one docs tree: a second configuration `INHERIT`s the first and APPENDS to its nav,
+#: and the navbar the build renders carries the entries of both. A repo with one configuration
+#: reads one, and this costs nothing.
+_SITE_CONFIG_RE = re.compile(r"^mkdocs(?:\..+)?\.ya?ml$")
 
 #: Where GitHub reads workflows, and the two file endings it accepts. Nothing below this
 #: directory is a workflow, and nothing above it is read.
@@ -86,7 +97,7 @@ VALE_ON = {"YES", "TRUE", "ON"}
 VALE_OFF = {"NO", "FALSE", "OFF"}
 
 #: The command a workflow step is allowed to run, and the table its task must be declared in.
-#: Both are named here because rule 11's problem text and its fix both spell them.
+#: Both are named here because rule 12's problem text and its fix both spell them.
 PIXI_RUN = "pixi run"
 TASK_TABLE = "[tool.pixi.tasks]"
 
@@ -176,9 +187,9 @@ class _TolerantLoader(yaml.SafeLoader):
     """A SafeLoader that reads a config it does not fully understand.
 
     mkdocs configurations carry local tags — `!ENV`, `!!python/name:...` for an emoji index — and
-    a plain `safe_load` raises on the first one. Rule 2 only wants `nav:` and `docs_dir:`, so an
-    unknown tag becomes ``None`` rather than an exception: a derived repo that adds one must not
-    turn a conformance rule into a crash.
+    a plain `safe_load` raises on the first one. Rules 2 and 13 only want `nav:`, `docs_dir:` and
+    `INHERIT:`, so an unknown tag becomes ``None`` rather than an exception: a derived repo that
+    adds one must not turn a conformance rule into a crash.
     """
 
 
@@ -317,6 +328,33 @@ def _steps(path: str, document: dict[Any, Any]) -> tuple[Step, ...]:
     return tuple(steps)
 
 
+@dataclass(frozen=True)
+class SiteConfig:
+    """One site configuration, and the nav entries it contributes to a build.
+
+    Attributes
+    ----------
+    path
+        Repo-relative path of the configuration file, e.g. `mkdocs.yml`.
+    docs_dir
+        The site source this file resolves its nav paths against, repo-relative, without a
+        trailing slash, and AFTER `INHERIT`: a configuration that inherits another and names no
+        source of its own resolves against the parent's.
+    declares_nav
+        Whether the file has a `nav:` key at all. A configuration with none is not one whose nav
+        is empty — the generator builds the navbar from the directory tree instead — so a rule
+        reports it as unchecked rather than green.
+    targets
+        Repo-relative path -> the nav string that named it, for every entry that names a page
+        rather than a link or a bare anchor.
+    """
+
+    path: str
+    docs_dir: str
+    declares_nav: bool
+    targets: dict[str, str]
+
+
 @dataclass
 class Repo:
     """The tree under inspection and the declarations it makes about itself."""
@@ -353,37 +391,92 @@ class Repo:
         """Whether anything tracked lives under a directory prefix."""
         return any(p.startswith(prefix) for p in self.tracked)
 
+    def config(self, rel: str) -> dict[str, Any]:
+        """One site configuration file, parsed, or an empty mapping when it is not there.
+
+        A file that will not parse, or that is not a mapping, becomes an empty configuration
+        rather than an exception, exactly as `workflows` does: a derived repo's unusual site
+        config must not turn a conformance rule into a crash.
+        """
+        text = self.read(rel)
+        if text is None:
+            return {}
+        try:
+            # Not `safe_load`: `_TolerantLoader` is SafeLoader plus a shrug at unknown tags.
+            loaded = yaml.load(text, Loader=_TolerantLoader)
+        except yaml.YAMLError:
+            loaded = None
+        return loaded if isinstance(loaded, dict) else {}
+
+    def resolved_docs_dir(self, rel: str) -> str:
+        """One configuration's site source, resolved along the `INHERIT` chain.
+
+        Walked rather than read from the one file, because a configuration that inherits another
+        and declares no `docs_dir` of its own uses the parent's, and reading only the child would
+        resolve its nav against a directory that is not the site source. `INHERIT` is a path
+        relative to the configuration that writes it.
+
+        The visited set is not defensive clutter: a cycle is a configuration nobody can build, and
+        it must not be a conformance crash either.
+        """
+        seen: set[str] = set()
+        while rel not in seen:
+            seen.add(rel)
+            document = self.config(rel)
+            declared = document.get("docs_dir")
+            if isinstance(declared, str):
+                return posixpath.normpath(declared).strip("/")
+            parent = document.get("INHERIT")
+            if not isinstance(parent, str):
+                break
+            rel = posixpath.normpath(posixpath.join(posixpath.dirname(rel), parent))
+        return DEFAULT_DOCS_DIR
+
     @cached_property
     def mkdocs(self) -> dict[str, Any]:
         """`mkdocs.yml`, or an empty mapping when the repo publishes no site."""
-        text = self.read("mkdocs.yml")
-        if text is None:
-            return {}
-        # Not `safe_load`: `_TolerantLoader` is SafeLoader plus a shrug at unknown tags.
-        loaded = yaml.load(text, Loader=_TolerantLoader)
-        return loaded if isinstance(loaded, dict) else {}
+        return self.config(SITE_CONFIG)
 
     @cached_property
     def docs_dir(self) -> str:
         """The site source directory, repo-relative and without a trailing slash."""
-        declared = self.mkdocs.get("docs_dir", DEFAULT_DOCS_DIR)
-        return posixpath.normpath(str(declared)).strip("/")
+        return self.resolved_docs_dir(SITE_CONFIG)
 
     @cached_property
     def nav(self) -> dict[str, str]:
-        """Repo-relative path -> the `nav:` entry that names it.
+        """Repo-relative path -> the `mkdocs.yml` nav entry that names it."""
+        return _nav_targets(self.docs_dir, self.mkdocs.get("nav"))
 
-        Nav paths are relative to `docs_dir`, so they are prefixed with it before they can be
-        compared with anything `git ls-files` said. Getting that wrong is not a false negative
-        that shows up later — it makes rule 2 pass vacuously, which is the failure this whole file
-        exists to prevent. External links are skipped: a nav entry may be a URL.
+    @cached_property
+    def site_configs(self) -> tuple[SiteConfig, ...]:
+        """Every tracked site configuration, in path order, with the nav each contributes.
+
+        TRACKED, like `workflows` and for the same reason: a configuration no checkout carries
+        builds no site.
+
+        EVERY one of them and not just `SITE_CONFIG`, because `INHERIT` joins navs rather than
+        replacing them: a configuration that inherits another and writes a `nav:` of its own adds
+        to the inherited list, and the navbar the build renders carries both. So the entries a
+        build renders are the UNION across the files. A rule reading one file would pass the
+        other's dead entry, and a rule merging them into a single nav would have to know which
+        file won; the union needs neither, because an entry is checked where it was written. A
+        repo with one configuration reads one, and this costs nothing.
         """
-        entries: dict[str, str] = {}
-        for raw in _walk_strings(self.mkdocs.get("nav")):
-            if "://" in raw or raw.startswith("#"):
+        found: list[SiteConfig] = []
+        for rel in self.tracked:
+            if not _SITE_CONFIG_RE.match(rel):
                 continue
-            entries[posixpath.normpath(f"{self.docs_dir}/{raw}")] = raw
-        return entries
+            document = self.config(rel)
+            docs_dir = self.resolved_docs_dir(rel)
+            found.append(
+                SiteConfig(
+                    path=rel,
+                    docs_dir=docs_dir,
+                    declares_nav="nav" in document,
+                    targets=_nav_targets(docs_dir, document.get("nav")),
+                )
+            )
+        return tuple(found)
 
     @cached_property
     def manifest(self) -> dict[str, Any]:
@@ -452,6 +545,31 @@ def _walk_strings(node: Any) -> Iterator[str]:
     elif isinstance(node, dict):
         for value in node.values():  # pyright: ignore[reportUnknownVariableType]
             yield from _walk_strings(value)
+
+
+#: A nav entry that is not a path into the site source. A URL with a scheme, a protocol-relative
+#: one, or a bare anchor on the page the reader is already on — none of them names a file, so none
+#: is a file that can be missing. The scheme half is what covers `mailto:`, which has no `//`.
+_NAV_LINK_RE = re.compile(r"^[a-z][a-z0-9+.\-]*:|^//|^#", re.IGNORECASE)
+
+
+def _nav_targets(docs_dir: str, nav: Any) -> dict[str, str]:
+    """Repo-relative path -> the `nav:` entry that named it, for one site configuration.
+
+    Nav paths are relative to `docs_dir`, so they are prefixed with it before they can be compared
+    with anything `git ls-files` said. Getting that wrong is not a false negative that shows up
+    later — it makes rule 2 pass vacuously, which is the failure this whole file exists to prevent.
+
+    Rules 2 and 13 read the same mapping, so what counts as a nav path is decided once. `normpath`
+    is what lets rule 13 see an entry reaching ABOVE the site source: `../README.md` under `docs/`
+    arrives here as `README.md`, outside the directory the builder copies.
+    """
+    targets: dict[str, str] = {}
+    for raw in _walk_strings(nav):
+        if _NAV_LINK_RE.match(raw):
+            continue
+        targets[posixpath.normpath(f"{docs_dir or '.'}/{raw}")] = raw
+    return targets
 
 
 def _task_names(node: Any) -> Iterator[str]:
@@ -637,7 +755,7 @@ def _python_pins(pyproject: dict[str, Any]) -> dict[str, str]:
     """Every pixi `python` pin, keyed by the table header that holds it.
 
     Features are read as well as the default table, because a repo that really supports a range
-    gives its floor an environment to resolve in, and rule 10 says so in its notes. A pin may be
+    gives its floor an environment to resolve in, and rule 11 says so in its notes. A pin may be
     written `python = "3.13.*"` or `python = { version = "3.13.*" }`; both are the same claim.
     """
     tables: set[tuple[str, ...]] = {("tool", "pixi", "dependencies")}
@@ -654,7 +772,7 @@ def _python_pins(pyproject: dict[str, Any]) -> dict[str, str]:
 
 
 # --------------------------------------------------------------------------------------
-# The rules. Twelve fail, two warn. Each returns what it found; nothing here exits or prints.
+# The rules. Thirteen fail, two warn. Each returns what it found; nothing here exits or prints.
 # --------------------------------------------------------------------------------------
 
 
@@ -1197,8 +1315,77 @@ def rule_workflow_step_tasks(repo: Repo) -> Result:
     return result
 
 
+def rule_nav_target_exists(repo: Repo) -> Result:
+    """13. Every `nav:` entry names a tracked page under that configuration's site source.
+
+    TRACKED and not merely present, because CI builds from a checkout. The one shape that
+    legitimately fails is a repo GENERATING pages into the site source at build time, whose
+    entries name nothing this can see; `[tool.liulab.waived]` is the answer there, and it is
+    printed on every run so the choice stays visible.
+    """
+    result = Result()
+    if not repo.site_configs:
+        result.notes.append(
+            f"not checked: no tracked {SITE_CONFIG}, so this repo publishes no site"
+        )
+        return result
+    tracked = set(repo.tracked)
+    for config in repo.site_configs:
+        # A file with no `nav:` at all has not passed: the generator builds the navbar from the
+        # directory tree instead, and there is no entry to resolve. Reported per configuration,
+        # so a repo whose second config only overrides the identity says so rather than looking
+        # like one whose nav was checked.
+        if not config.declares_nav:
+            result.notes.append(
+                f"not checked: {config.path} declares no `nav:`, so the site builds its navbar "
+                "from the directory tree and names no page for this rule to resolve"
+            )
+            continue
+        prefix = f"{config.docs_dir}/" if config.docs_dir not in {"", "."} else ""
+        for target, raw in sorted(config.targets.items()):
+            # OUTSIDE the site source first, because such a target usually does exist — and a
+            # file that is right there is the case a "does it exist" test calls fine. It is the
+            # same broken menu item, so it is the same rule, with the fix it actually needs.
+            if prefix and not target.startswith(prefix):
+                result.problems.append(
+                    _problem(
+                        f"{config.path} nav entry `{raw}` resolves to {target}, outside {prefix}",
+                        "a nav path is read relative to the site source, and the builder renders "
+                        "that directory and nothing else. A target above it is not a page the "
+                        "site has, so the menu item 404s exactly as a missing file does — and the "
+                        "file being right there is what makes it read as correct",
+                        f"move the page under {prefix}, or write the entry as a URL if it is a "
+                        "link out rather than a page of this site",
+                    )
+                )
+            elif target not in tracked:
+                # A file that is present but untracked builds on the laptop that wrote it and
+                # nowhere else. Same failure, and worth saying apart, because "it is right there"
+                # is exactly what the person reading this will be about to say.
+                loose = (
+                    " The file is present on disk but untracked, and CI builds from a checkout."
+                    if repo.exists(target)
+                    else ""
+                )
+                result.problems.append(
+                    _problem(
+                        f"{config.path} nav entry `{raw}` names {target}, which is not tracked",
+                        "the site generator does not validate the nav at all: the build reports "
+                        "no issues, exits 0, and publishes a menu item whose link points at a "
+                        f"page that was never rendered.{loose} No build setting turns this on, "
+                        "which is why the check is here",
+                        f"add {target}, correct the entry, or delete it from the `nav:` list in "
+                        f"{config.path}",
+                    )
+                )
+        result.notes.append(
+            f"{config.path}: {len(config.targets)} nav entry(s) against {prefix or 'the repo root'}"
+        )
+    return result
+
+
 def warning_init_sentinel(repo: Repo) -> Result:
-    """13. `AGENTS.md` still carries the line telling you to run `/init`."""
+    """14. `AGENTS.md` still carries the line telling you to run `/init`."""
     result = Result()
     if repo.exists(INIT_SKILL):
         result.notes.append(f"not checked: {INIT_SKILL}/ is here, and that skill is the nag")
@@ -1321,6 +1508,14 @@ RULES: tuple[Rule, ...] = (
     ),
     Rule(
         13,
+        "nav-target-exists",
+        "every `nav:` entry in every tracked site configuration names a tracked file under that "
+        "configuration's site source. This is the one broken site the generator does not validate "
+        "at all — it builds green, reports no issues, and publishes a menu item that 404s",
+        rule_nav_target_exists,
+    ),
+    Rule(
+        14,
         "init-sentinel",
         "AGENTS.md is still the template's generic copy",
         warning_init_sentinel,
@@ -1328,9 +1523,9 @@ RULES: tuple[Rule, ...] = (
     ),
 )
 
-#: Warning 14 is not a rule with a tree to inspect: it is the waiver table itself, printed on
+#: Warning 15 is not a rule with a tree to inspect: it is the waiver table itself, printed on
 #: every run. It lives in `report` because only the reporter knows what each waiver suppressed.
-WAIVER_RULE = (14, "waivers")
+WAIVER_RULE = (15, "waivers")
 
 
 def load(root: Path) -> Repo:
@@ -1381,7 +1576,7 @@ def _verdict(repo: Repo, rule: Rule, result: Result) -> tuple[str, list[str]]:
 
 
 def _waiver_lines(repo: Repo, results: list[tuple[Rule, Result]]) -> list[str]:
-    """Warning 14: every waiver, with what it actually suppressed.
+    """Warning 15: every waiver, with what it actually suppressed.
 
     A waiver naming no rule is called out rather than ignored, and so is one naming rule 1, which
     refuses to be waived. A waiver that quietly does nothing is the same invisible escape hatch

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -7,6 +7,13 @@
 It states the RULE, not the file contents — a pull model, so a repo that legitimately diverges
 stays green while the shared conventions stay checked. Fifteen rules: thirteen fail, two only warn.
 
+Three exit statuses, spelled the way `scripts/check.sh` spells its own: **0** every rule passed,
+**1** it ran and a rule failed, **2** it could not run at all — no `.git` to list tracked files
+from, no `pyproject.toml`, a manifest that will not parse. The last is not a repo that broke a
+rule, it is a repo nothing checked, and the two want opposite answers: fix the repo, or fix the
+invocation. One exit code for both sends whoever reads the log hunting a violation that is not
+there.
+
 Three things it does on purpose:
 
 - **It collects every failure.** One run tells you everything to fix, the same idiom
@@ -48,6 +55,23 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
+
+#: The three exit statuses, named so the contract is written once and read where it is returned.
+#: `CANNOT_RUN` is the one that says nothing about this repo's rules: `scripts/check.sh` already
+#: spells "could not run" as 2 — a usage error, a capture directory it could not make — and a
+#: checker that exited 1 for both would have every reader looking for a rule violation instead of
+#: for the missing checkout. `tests/test_conformance.py` asserts all three.
+PASSED, FAILED, CANNOT_RUN = 0, 1, 2
+
+
+class CannotRunError(Exception):
+    """The tree could not be read at all, so no rule was checked.
+
+    Raised by :func:`load` and turned into `CANNOT_RUN` by :func:`main`. It is deliberately not a
+    `SystemExit` carrying a message: Python prints such a message and exits **1**, which is the
+    status a failed rule already uses, and that is the conflation this class exists to remove.
+    """
+
 
 #: The template's placeholder module name, SPELLED IN TWO PIECES on purpose. `init-repo`
 #: substitutes that name throughout the tree and the dogfood job then greps a rendered repo for
@@ -1529,7 +1553,12 @@ WAIVER_RULE = (15, "waivers")
 
 
 def load(root: Path) -> Repo:
-    """Read the tree and the declarations, or explain why that was not possible."""
+    """Read the tree and the declarations, or raise :class:`CannotRunError` saying why not.
+
+    Every condition here is the same one: the inputs every rule reads are not there, so the answer
+    is unknown rather than bad. None of them is a rule this repo broke, and :func:`main` gives them
+    all `CANNOT_RUN` for that reason.
+    """
     proc = subprocess.run(
         ["git", "-C", str(root), "ls-files", "-z"],
         capture_output=True,
@@ -1537,12 +1566,18 @@ def load(root: Path) -> Repo:
         check=False,
     )
     if proc.returncode != 0:
-        raise SystemExit(f"conformance: cannot list tracked files in {root}\n{proc.stderr.strip()}")
+        raise CannotRunError(f"cannot list tracked files in {root}\n{proc.stderr.strip()}")
     tracked = tuple(sorted(p for p in proc.stdout.split("\0") if p))
     pyproject = root / "pyproject.toml"
     if not pyproject.is_file():
-        raise SystemExit(f"conformance: no pyproject.toml in {root}")
-    tool = tomllib.loads(pyproject.read_text(encoding="utf-8")).get("tool", {})
+        raise CannotRunError(f"no pyproject.toml in {root}")
+    try:
+        parsed = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError) as reason:
+        # A manifest nothing can parse is the declarations MISSING, not a rule broken — and a
+        # traceback here would exit 1, reading as a failed rule with an unusually bad report.
+        raise CannotRunError(f"cannot read pyproject.toml in {root}\n{reason}") from reason
+    tool = parsed.get("tool", {})
     liulab = tool.get("liulab", {})
     return Repo(
         root=root,
@@ -1640,7 +1675,7 @@ def report(repo: Repo, results: list[tuple[Rule, Result]]) -> int:
     total = sum(1 for rule, _ in results if not rule.warns_only)
     if not failed:
         print(f"\nAll {total} rules pass.")
-        return 0
+        return PASSED
     # Flushed before the first byte reaches stderr. `check.sh` captures both streams into one
     # file, where stdout is block-buffered and stderr is not, so without this the failures print
     # above the table that says which rules they came from.
@@ -1654,11 +1689,15 @@ def report(repo: Repo, results: list[tuple[Rule, Result]]) -> int:
         for problem in result.problems:
             print(textwrap.indent(problem, "  "), file=sys.stderr)
         print("", file=sys.stderr)
-    return 1
+    return FAILED
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run every rule against one tree and report."""
+    """Run every rule against one tree and report, returning the exit status.
+
+    `PASSED` or `FAILED` once the rules have run, and `CANNOT_RUN` when :func:`load` says the tree
+    could not be read — the one answer that is about the invocation and not about the repo.
+    """
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -1670,7 +1709,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Repository to check. Defaults to the repo this script lives in.",
     )
     args = parser.parse_args(argv)
-    repo = load(args.root.resolve())
+    try:
+        repo = load(args.root.resolve())
+    except CannotRunError as reason:
+        print(f"conformance: {reason}", file=sys.stderr)
+        print("conformance: nothing was checked. This is not a rule failure.", file=sys.stderr)
+        return CANNOT_RUN
     results = [(rule, rule.check(repo)) for rule in RULES]
     return report(repo, results)
 

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -10,6 +10,10 @@ marks THAT rule FAIL and names the offending file. The rule name alone would pro
 status table prints all fifteen names on every run, passing or failing, so the assertions read the
 status word out of the table rather than grepping the output for a name.
 
+The exit status is checked here too, all three of it: 0, 1 when a rule failed, and 2 when the
+checker could not run at all. A checker that could not run has checked nothing, and it must not
+report that as a rule this repo broke.
+
 Conformance is invoked as a SUBPROCESS, so what is under test is the command an agent runs and
 CI runs, not an internal function that could be refactored into something the command no longer
 calls.
@@ -17,6 +21,7 @@ calls.
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -188,19 +193,32 @@ def repo(tmp_path: Path) -> Path:
     return root
 
 
-def conformance(root: Path) -> subprocess.CompletedProcess[str]:
+def conformance(
+    root: Path, *, stage: bool = True, ceiling: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     """Run the checker over one tree, the way a person and CI run it.
 
     `git add -A` first, because every rule reads `git ls-files`: until a fixture's edit is staged
     it does not exist as far as conformance is concerned. Nothing is committed — no rule reads
-    history, and a commit would need an identity this environment may not have.
+    history, and a commit would need an identity this environment may not have. `stage=False` is
+    for the one tree that is not a repo at all, where there is nothing to stage into.
+
+    `ceiling` is what makes such a tree genuinely repo-less. `git ls-files` walks UP from its
+    working directory, so a scratch directory inherits whatever repository happens to be above it —
+    and a test that relied on the temporary directory sitting outside one would pass or fail on
+    where the machine puts its temporary files. `GIT_CEILING_DIRECTORIES` stops the walk there.
     """
-    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    if stage:
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    env = dict(os.environ)
+    if ceiling is not None:
+        env["GIT_CEILING_DIRECTORIES"] = str(ceiling)
     return subprocess.run(
         [sys.executable, str(CONFORMANCE), "--root", str(root)],
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
 
 
@@ -261,6 +279,57 @@ def test_a_tree_that_has_skills_passes_every_rule(repo: Path) -> None:
     assert verdicts["skill-name-prefix"] == "ok"
     assert verdicts["skill-symlinks"] == "ok"
     assert "1 skill" in proc.stdout
+
+
+# The exit status is a three-way answer and not a boolean, so all three are asserted here rather
+# than left implied by the rule tests below. "A rule failed" means fix the repo; "could not run"
+# means the checker never ran and the repo was never checked, and one status for both sends the
+# reader of a CI log hunting a violation that does not exist. 2 is the same word
+# `scripts/check.sh` uses for a usage error and for a capture directory it could not make.
+
+
+def test_it_exits_0_when_it_ran_and_every_rule_passed(repo: Path) -> None:
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "All 13 rules pass." in proc.stdout
+
+
+def test_it_exits_1_when_it_ran_and_a_rule_failed(repo: Path) -> None:
+    write(repo, "README.md", f"# liulab-{PLACEHOLDER}\n\nA repo that was never renamed.\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert "1 of 13 rules failed" in proc.stderr
+
+
+def test_it_exits_2_when_there_is_no_git_to_list_tracked_files_from(tmp_path: Path) -> None:
+    # Every rule reads `git ls-files`, so without a repository NOTHING was checked — the state CI
+    # would be in given a source archive instead of a checkout. The tree is otherwise complete, so
+    # the missing `.git` is the only thing under test.
+    plain = tmp_path / "plain"
+    write(plain, "pyproject.toml", PYPROJECT)
+    proc = conformance(plain, stage=False, ceiling=tmp_path)
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "cannot list tracked files" in proc.stderr
+    assert "not a rule failure" in proc.stderr
+
+
+def test_it_exits_2_when_there_is_no_pyproject_toml(repo: Path) -> None:
+    # The declarations every rule reads about themselves live there — the agent-docs table, the
+    # waivers, the task list. Without it the answer is unknown, not bad.
+    (repo / "pyproject.toml").unlink()
+    proc = conformance(repo)
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "no pyproject.toml" in proc.stderr
+
+
+def test_it_exits_2_when_the_manifest_will_not_parse(repo: Path) -> None:
+    # Same class as an absent manifest, and it must not be a traceback: an uncaught exception exits
+    # 1, which would read as a failed rule with an unusually bad report.
+    write(repo, "pyproject.toml", "[project\nname = 'example'\n")
+    proc = conformance(repo)
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "cannot read pyproject.toml" in proc.stderr
+    assert "Traceback" not in proc.stderr
 
 
 def test_rule_1_fires_on_a_tracked_placeholder(repo: Path) -> None:

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -7,7 +7,7 @@ checked by no rule at all, with zero alerts and green CI. So the claim these tes
 
 Every test builds a tmp_path tree that is correct in every respect but one, and asserts the run
 marks THAT rule FAIL and names the offending file. The rule name alone would prove nothing: the
-status table prints all fourteen names on every run, passing or failing, so the assertions read the
+status table prints all fifteen names on every run, passing or failing, so the assertions read the
 status word out of the table rather than grepping the output for a name.
 
 Conformance is invoked as a SUBPROCESS, so what is under test is the command an agent runs and
@@ -115,7 +115,7 @@ def publishes(root: Path, on: str) -> None:
 
     The body is a real job with real steps, not a bare `on:` block: the accessor the rule reads
     parses the whole file, and a fixture that carried triggers alone would never exercise that.
-    Its one command invokes `build`, which `PYPROJECT` declares, so rule 11 stays green here and
+    Its one command invokes `build`, which `PYPROJECT` declares, so rule 12 stays green here and
     rule 9 is the only thing these trees vary.
     """
     write(
@@ -135,7 +135,7 @@ def publishes(root: Path, on: str) -> None:
 def runs(root: Path, *commands: str, job: str = "check") -> None:
     """A `ci.yml` whose one job checks out an action and then runs each command given.
 
-    Not `release.yml`: that path is rule 9's premise and rule 8's, and a rule 11 fixture must vary
+    Not `release.yml`: that path is rule 9's premise and rule 8's, and a rule 12 fixture must vary
     nothing but the commands. The leading `uses:` step is in every tree here on purpose — it is
     what proves an action step is passed over rather than merely absent.
     """
@@ -166,7 +166,7 @@ def repo(tmp_path: Path) -> Path:
 
     It has no `src/`, no workflow at all and so no release workflow, so rule 8's two conditionals,
     rule 9 and rule 11 are all vacuous here; the tests that care add the premise, through
-    `publishes` and `runs`. It has no `skills/init-repo/`, so rule 1 and warning 12 are both live
+    `publishes` and `runs`. It has no `skills/init-repo/`, so rule 1 and warning 14 are both live
     — the state a derived repo is in, and the only state where they check anything.
     """
     root = tmp_path / "repo"
@@ -208,7 +208,7 @@ def statuses(proc: subprocess.CompletedProcess[str]) -> dict[str, str]:
     """The verdict the run gave each rule, read off its own status table.
 
     Asserting on the status word rather than on the presence of a rule NAME is the point: the
-    table prints all fourteen names on every run, so `"repo-shape" in output` is true of a green run
+    table prints all fifteen names on every run, so `"repo-shape" in output` is true of a green run
     and would prove nothing at all.
     """
     found: dict[str, str] = {}
@@ -241,6 +241,7 @@ def test_the_fixture_tree_passes_every_rule(repo: Path) -> None:
         "single-toolchain",
         "python-version-agreement",
         "workflow-step-tasks",
+        "nav-target-exists",
         "init-sentinel",
         "waivers",
     }
@@ -283,7 +284,7 @@ def test_rule_1_fires_on_a_placeholder_in_a_path_not_only_in_a_file(repo: Path) 
 
 def test_rule_1_is_not_checked_while_the_init_skill_is_there(repo: Path) -> None:
     # The template ships the placeholder ON PURPOSE, and `skills/init-repo/` is what says the
-    # rename has not happened yet. Same discriminator warning 11 uses.
+    # rename has not happened yet. Same discriminator warning 14 uses.
     write(repo, "README.md", f"# liulab-{PLACEHOLDER}\n\nStill the template.\n")
     add_skill(repo, "init-repo")
     proc = conformance(repo)
@@ -303,7 +304,7 @@ def test_rule_1_refuses_to_be_waived(repo: Path) -> None:
     assert proc.returncode == 1
     assert statuses(proc)["placeholder-rename"] == "FAIL"
     assert "cannot be waived" in proc.stderr
-    assert "REFUSED" in proc.stdout  # and warning 13 still prints it
+    assert "REFUSED" in proc.stdout  # and the waiver table still prints it
 
 
 def test_rule_2_fires_on_a_page_that_is_not_excluded_from_search(repo: Path) -> None:
@@ -332,6 +333,9 @@ def test_rule_2_follows_a_docs_dir_the_site_moved(repo: Path) -> None:
     write(
         repo, "mkdocs.yml", "site_name: example\ndocs_dir: site-source\nnav:\n  - Home: index.md\n"
     )
+    # The page the moved nav names, so rule 13 is green here and rule 2 is the only rule this
+    # tree is about.
+    write(repo, "site-source/index.md", "# example\n\nThe front page.\n")
     proc = conformance(repo)
     # Nothing under `site-source/` is declared agent-facing, so the rule has nothing to check —
     # and says so, rather than reporting a green it did not earn.
@@ -516,7 +520,7 @@ def test_rule_9_is_vacuous_and_not_passing_when_the_repo_publishes_nothing(repo:
     )
 
 
-def test_warning_12_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> None:
+def test_warning_14_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> None:
     write(
         repo,
         "AGENTS.md",
@@ -528,7 +532,7 @@ def test_warning_12_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> No
     assert "AGENTS.md still carries the `/init` sentinel" in flat(proc.stdout)
 
 
-def test_warning_12_is_silent_while_the_init_skill_is_the_nag(repo: Path) -> None:
+def test_warning_14_is_silent_while_the_init_skill_is_the_nag(repo: Path) -> None:
     write(
         repo,
         "AGENTS.md",
@@ -549,7 +553,7 @@ def test_a_waiver_suppresses_its_rule_and_is_still_printed(repo: Path) -> None:
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert statuses(proc)["glossary-entry-length"] == "waived"
     assert f"1 problem(s) suppressed: {reason}" in flat(proc.stdout)
-    # and warning 13 prints it a second time, in the waiver table
+    # and warning 15 prints it a second time, in the waiver table
     assert f"glossary-entry-length: 1 problem(s) suppressed — {reason}" in flat(proc.stdout)
 
 
@@ -582,7 +586,7 @@ def test_every_failure_is_reported_and_not_just_the_first(repo: Path) -> None:
     assert verdicts["agent-docs-unpublished"] == "FAIL"
     assert verdicts["skill-file-location"] == "FAIL"
     assert verdicts["repo-shape"] == "FAIL"
-    assert "3 of 12 rules failed" in proc.stderr
+    assert "3 of 13 rules failed" in proc.stderr
 
 
 def test_rule_10_fires_on_a_pre_commit_configuration(repo: Path) -> None:
@@ -661,7 +665,7 @@ def pyproject_python(
 ) -> str:
     """The fixture's pyproject plus whichever Python declarations one test wants.
 
-    A builder rather than five literals because rule 10 is about the COMBINATION: every test
+    A builder rather than five literals because rule 11 is about the COMBINATION: every test
     below differs only in which sites it fills in and what each of them says.
     """
     text = PYPROJECT
@@ -974,3 +978,133 @@ def test_a_workflow_that_will_not_parse_is_read_as_empty_and_not_as_an_exception
     assert "Traceback" not in proc.stderr
     assert statuses(proc)["workflow-step-tasks"] == "ok"
     assert "1 step(s) that run a command, across 2 workflow(s)" in flat(proc.stdout)
+
+
+def test_rule_13_fires_on_a_nav_entry_naming_a_file_that_is_not_there(repo: Path) -> None:
+    # The hole this rule exists for. Measured on the pinned site generator: it does not validate
+    # the nav at all, so `--strict` reports "No issues found", exits 0, and publishes a menu item
+    # whose href points at a page that was never rendered.
+    write(repo, "mkdocs.yml", MKDOCS + "  - Ghost: ghost.md\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["nav-target-exists"] == "FAIL"
+    assert (
+        "mkdocs.yml nav entry `ghost.md` names docs/ghost.md, which is not tracked" in proc.stderr
+    )
+    assert "delete it from the `nav:` list in mkdocs.yml" in flat(proc.stderr)
+
+
+def test_rule_13_passes_a_nav_whose_pages_are_all_there(repo: Path) -> None:
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "ok"
+    # The anti-vacuity assertion: a rule handed no entries passes every nav ever written, so the
+    # green above means something only once the run says how many entries it resolved.
+    assert "mkdocs.yml: 2 nav entry(s) against docs/" in flat(proc.stdout)
+
+
+def test_rule_13_is_vacuous_and_not_passing_when_the_repo_publishes_no_site(repo: Path) -> None:
+    # One lab repo ships no docs site at all. Nothing was checked, and a green here would read as
+    # "every menu item resolves", which this run has no evidence for.
+    (repo / "mkdocs.yml").unlink()
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "--"
+    assert "not checked: no tracked mkdocs.yml, so this repo publishes no site" in flat(proc.stdout)
+
+
+def test_rule_13_is_vacuous_when_the_site_declares_no_nav(repo: Path) -> None:
+    # No `nav:` is not an empty nav. The generator builds the navbar from the directory tree
+    # instead, so there is no entry to resolve and nothing was checked.
+    write(repo, "mkdocs.yml", "site_name: example\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "--"
+    assert "not checked: mkdocs.yml declares no `nav:`" in flat(proc.stdout)
+
+
+def test_rule_13_does_not_flag_a_link_or_an_anchor(repo: Path) -> None:
+    # A nav entry may point out of the site entirely. None of these three names a file, so none
+    # of them is a file that can be missing — and the count proves the two real pages were still
+    # the thing checked.
+    write(
+        repo,
+        "mkdocs.yml",
+        MKDOCS
+        + "  - Issues: https://github.com/liuhlab/example/issues\n"
+        + "  - Mail: mailto:lab@example.org\n"
+        + "  - Top: '#top'\n",
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "ok"
+    assert "mkdocs.yml: 2 nav entry(s) against docs/" in flat(proc.stdout)
+
+
+def test_rule_13_fires_on_a_page_that_exists_but_sits_outside_the_site_source(repo: Path) -> None:
+    # The second class, and the reason it is the same rule rather than a separate concern:
+    # `README.md` really is there, so a check that only asked whether the file exists would call
+    # this fine. The builder renders the site source and nothing else, so the menu item 404s
+    # exactly as a missing page does — and the fix is a different one, so it says so.
+    write(repo, "README.md", "# example\n\nThe repo.\n")
+    write(repo, "mkdocs.yml", MKDOCS + "  - Readme: ../README.md\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["nav-target-exists"] == "FAIL"
+    assert "nav entry `../README.md` resolves to README.md, outside docs/" in proc.stderr
+    assert "move the page under docs/" in flat(proc.stderr)
+
+
+def test_rule_13_fires_on_a_page_that_is_present_on_disk_but_untracked(repo: Path) -> None:
+    # It builds on the laptop that wrote it and nowhere else, because CI builds from a checkout.
+    # The problem says which of the two it is, since "it is right there" is what the person
+    # reading the failure is about to say.
+    write(repo, ".gitignore", "docs/draft.md\n")
+    write(repo, "docs/draft.md", "# Draft\n\nNever committed.\n")
+    write(repo, "mkdocs.yml", MKDOCS + "  - Draft: draft.md\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["nav-target-exists"] == "FAIL"
+    assert "names docs/draft.md, which is not tracked" in proc.stderr
+    assert "present on disk but untracked, and CI builds from a checkout" in flat(proc.stderr)
+
+
+def test_rule_13_reads_a_second_configuration_that_inherits_the_first(repo: Path) -> None:
+    # The shape this template itself has: a second config INHERITs `mkdocs.yml`, and its `nav:`
+    # APPENDS to the inherited one rather than replacing it, so both files' entries are in the
+    # navbar the build renders. A rule reading only `mkdocs.yml` would call this tree green.
+    write(repo, "mkdocs.other.yml", "INHERIT: mkdocs.yml\nnav:\n  - Extra: extra.md\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["nav-target-exists"] == "FAIL"
+    assert (
+        "mkdocs.other.yml nav entry `extra.md` names docs/extra.md, which is not tracked"
+        in proc.stderr
+    )
+
+
+def test_rule_13_resolves_an_inherited_docs_dir_and_not_the_default(repo: Path) -> None:
+    # The second configuration names no `docs_dir` of its own, so its nav paths resolve against
+    # the one it inherits. A rule that assumed `docs/` here would report a page that is there —
+    # a false failure on the exact two-file shape this template ships.
+    write(
+        repo, "mkdocs.yml", "site_name: example\ndocs_dir: site-source\nnav:\n  - Home: index.md\n"
+    )
+    write(repo, "site-source/index.md", "# example\n\nThe front page.\n")
+    write(repo, "site-source/extra.md", "# Extra\n\nA second page.\n")
+    write(repo, "mkdocs.other.yml", "INHERIT: mkdocs.yml\nnav:\n  - Extra: extra.md\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "ok"
+    assert "mkdocs.other.yml: 1 nav entry(s) against site-source/" in flat(proc.stdout)
+
+
+def test_rule_13_reads_a_site_config_that_will_not_parse_as_empty(repo: Path) -> None:
+    # A derived repo's unusual site config must not turn a conformance rule into a crash. It
+    # contributes no nav, and the configuration that could be read is still reported on.
+    write(repo, "mkdocs.broken.yml", "nav: [\n  - x: }{\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "Traceback" not in proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "ok"
+    assert "not checked: mkdocs.broken.yml declares no `nav:`" in flat(proc.stdout)


### PR DESCRIPTION
The two follow-ups filed during PR #54, plus four more found while doing them. Three of the six
came from auditing an older sibling repo against this template, and were invisible here.

## What lands

| Issue | Change |
| --- | --- |
| #52 | Require annotated parameters — and *decline* the sibling rule that cannot be held |
| #53 | Conformance fails a nav entry naming a page the site does not have |
| #55 | Say how to fix a readability failure, not just that one exists |
| #56 | Scope the duplicate-heading rule so a correct changelog passes |
| #57 | Exit 2 when conformance could not run, distinct from the 1 a failed rule exits |
| #58 | Say to measure a cap with the gate, not with `wc` |

Conformance goes from fourteen rules to fifteen: thirteen that fail, two that warn.

## #52 was a decision, and the answer was neither option

The issue offered adopt-both or decline-both. The two rules are not a pair.
`reportMissingParameterType` is **syntactic and local** — `Any` satisfies it, so the fix is
always in the file you are editing and nothing upstream can turn it red. `reportUnknownParameterType`
is **semantic and transitive**: it fails parameters that *are* annotated (`def b(xs: list)`) and
its verdict depends on every dependency shipping complete types. Adopted the first, declined the
second, with the reason in the config so nobody restores it as an oversight.

**This undercut the issue's own evidence.** Both rules cost zero here — but only because no
parameter happens to carry a type an untyped library owns. The third member of that family,
`reportUnknownVariableType`, costs 20 errors on this tree with the existing `# pyright: ignore`
comments in place and 25 with them stripped. The measurement I filed the issue with was not
representative of its own rule family.

No per-directory exemption. The ruff `tests/**` precedent rests on *audience* — a docstring
serves a caller, a test has none. An annotation serves the **checker**, so exempting tests would
remove checking, not relax documentation.

## Verified rather than asserted

- **#53** re-measured the hole instead of trusting #51: with a bad nav entry, `docs-build` printed
  "No issues found", exited 0, and shipped a dead href. It reads **every** tracked `mkdocs*.yml`
  and takes the union, because `INHERIT` joins navs rather than replacing them — measured, not
  assumed. Its dogfood run caught a real defect on the first pass (its own: three docstrings named
  a template-only file no derived repo has).
- **#56** rebuilt the negative test both directions. Default fails a *correct* two-release
  changelog; `siblings_only` still fails a release repeating its own section.
- **#57** found a third load failure nobody had noticed: an unparseable `pyproject.toml` escaped
  as a **traceback**, exit 1, reading as a failed rule. Its non-git test needed
  `GIT_CEILING_DIRECTORIES`, because `git ls-files` walks *up* and a scratch dir silently inherits
  whatever repo sits above the temp dir.

## The pattern underneath

Three defects here — pyright's `standard` mode, the nav validation, MD024 — are **age-dependent**.
They need code someone stopped annotating, a page that moved, a second release. The dogfood job
proves a *fresh* repo passes, so it is structurally incapable of finding this class. That is a
blind spot with a shape, and the remedy is repeating the audit against an older repo, not more
machinery.

## Two corrections on the record

#55 and #58 both state word counts. The first version of #55's were `wc -w` figures, and `wc` is
not what enforces the cap — it counts table pipes and link targets as words, overstating by 10%
to 65% depending on markup density. Corrected on the issue. Then, while closing #58, I asserted a
vale count instead of measuring it and had to correct that too. Both corrections are recorded on
their issues rather than edited away, because the second happened *in the act of closing the issue
about it*.

Closes #52, closes #53, closes #55, closes #56, closes #57, closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZNsHzTC77n87dtoGiN581
