### PR TITLE
Narrow five rules that fired on correct work, and write down the restraint that should have stopped them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@
 # is the whole reason it is a job of its own.
 #
 # Every step invokes `pixi run <task>` and never a command line. The step list lives in
-# `pyproject.toml` — `check-static` names it once — so this file and a laptop cannot drift:
-# adding a step is one more word there and nothing here. This paragraph is the advice and
-# conformance rule `workflow-step-tasks` is the enforcement, over every workflow in the
-# repo and not only this one; they say one thing, so they change together.
+# `pyproject.toml` — `check-static` names it once — so adding a step is one more word
+# there and nothing here. Conformance rule `workflow-step-tasks` holds every workflow in
+# the repo to it, and what it checks is that the command came from the task table: a step
+# may pass arguments after `--`, and the rule prints them rather than forbidding them.
+# It reads the `run:` line only, so `env:`, `working-directory:`, `shell:` and a local
+# composite action can still make a step do something no `pixi run` does here. Keeping
+# CI and a laptop the same is a habit this file keeps, not a property anything proves.
 #
 # Not shipped, deliberately: a `claude.yml`, because on a public repo anyone who can
 # comment could spend the API budget; container and benchmark workflows, because nothing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@
 name: release
 
 on:
-  # NEVER a trigger that a tag push can fire — `push: tags:`, a `push:` with no branch
-  # filter, or `create`. `init-repo` pushes `v0.0.0` on a repo's first day so the version
-  # does not read as if a release already happened, and any of those would fire a PyPI
-  # publish right then, from a repo nobody has finished naming. Publishing a GitHub Release
-  # is a deliberate act by a person, so that is the trigger. This paragraph is the advice
-  # and conformance rule `release-trigger` is the enforcement; they say one thing, so they
-  # change together.
+  # NEVER a trigger that pushing `v0.0.0` can fire — a `push:` with no branch filter,
+  # `create`, or a `tags:` filter that admits it. `init-repo` pushes `v0.0.0` on a repo's
+  # first day so the version does not read as if a release already happened, and any of
+  # those would fire a PyPI publish right then, from a repo nobody has finished naming.
+  # Publishing a GitHub Release is a deliberate act by a person, so that is the trigger.
+  # This paragraph is the advice and conformance rule `release-trigger` is the enforcement;
+  # they say one thing, so they change together.
   release:
     types: [published]
   # For a release whose publish failed on something outside the code — a missing trusted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ CONTEXT.md        the glossary — the words this repo uses
 | Step | Tool |
 | --- | --- |
 | `lint`, `fmt-check` | ruff |
-| `typecheck` | pyright, `standard` mode, plus annotated parameters |
+| `typecheck` | pyright, `standard` mode, plus annotated parameters outside `tests/` |
 | `vale`, `markdownlint` | the writing rules |
 | `conformance` | the repo still matches the template's rules |
 | `test` | pytest |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,23 @@
 One paragraph: what this package is for, who uses it, and the one thing that is easy to get
 wrong. Distribution name **`liulab-newpkg`**, import name **`newpkg`**.
 
+## Restraint
+
+Generalizable, lightweight, uncustomized — in that order, and ahead of thorough.
+
+Every gate, lint rule, cap and check is paid by everyone who works here afterwards. They
+arrive one at a time, each reasonable alone, and nothing measures the sum. So before adding
+one:
+
+- **Does it generalize?** A rule shaped by one situation belongs where that situation is.
+  Evidence that it helps there is not evidence about here.
+- **What is the total?** Count what someone must already satisfy before writing any code.
+- **Would a narrower rule do?** Prefer narrowing to forbidding a legitimate practice.
+
+**A measurement outranks a hypothesis.** When a rule is shown to fire on correct work, that
+is evidence; a defect it might also catch is not. Declining a rule, or removing one that
+misfires, is as much a contribution as adding one.
+
 ## Toolchain
 
 - **pixi** is the only supported toolchain. Never bare pip, uv, or conda. `pyproject.toml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ sets one.
   that a parameter is annotated at all — the bar was kept by discipline and nothing would
   have noticed a repo dropping it. Its sibling `reportUnknownParameterType` was considered
   and declined: it also fails parameters that *are* annotated when the type belongs to an
-  untyped dependency, which is not a bar a lab repo can hold.
+  untyped dependency, which is not a bar a lab repo can hold. `tests/` is scoped back to
+  plain `standard`, because the rule fired on fixtures and `parametrize` arguments, where
+  the annotation it asks for is a claim nothing compares to the fixture.
 - A conformance rule that fails a `nav:` entry naming a file the repo does not track, or one
   that sits outside the site source. That is the broken site the builder does not validate
   at all — it reports no issues, exits 0, and publishes a menu item that 404s — so the check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,10 @@ sets one.
   `init-repo` deletes them, takes `-f mkdocs.template.yml` off the two docs tasks, and cuts
   the front page's pointer at the page.
 - Docstring examples as tests. `pytest` collects the doctests in `src/` alongside `tests/`,
-  so an example that has drifted from the code it documents fails the gate. `docs/api.md`
-  says how to mark a line that cannot run offline.
+  so an example that has drifted from the code it documents fails the gate. Writing an
+  example is voluntary; the ones that exist are checked. `docs/api.md` says how to mark a
+  line that cannot run offline. Collecting `src/` imports it, so a module that needs an
+  absent optional dependency costs one error instead of aborting the whole suite.
 - A `validation:` block in `mkdocs.yml` turning on the five link checks the site builder
   ships switched off, and a comment beside it listing, from measurement, which broken links
   a strict build catches and which three it lets through. A `nav:` entry naming a file that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,15 @@ sets one.
   take a separate value was measured off `pixi run --help` and had eight spellings of twelve
   options, so `pixi run -p linux-64 build` — a step that literally is `pixi run <task>` — was
   being told it ran a command.
+- The conformance rule about `nav:` entries now resolves only the entries that name a page —
+  ending `.md`, `.ipynb` or `.html` — and strips a trailing `#anchor` first. A directory entry,
+  an `...`, and `guide.md#install` were each measured failing a correct site, and the fix printed
+  for the second was "add docs/...". Whatever it did not resolve is listed in the notes, so a
+  passed-over entry is visible rather than silently uncounted.
+- A site configuration that declares a page-generating plugin — `gen-files`, `literate-nav`,
+  `awesome-pages`, `macros` — now reports that rule not checked, with the reason. Such a repo had
+  to waive the whole rule on first contact, and a waiver is per rule: one generated section
+  turned the check off for every hand-written entry it exists to protect, dead links included.
 - `ci.yml`'s header no longer says CI and a laptop cannot drift. The rule reads the `run:` line
   and nothing else, so `env:`, `working-directory:`, `shell:` and a local composite action can
   each change what a step does without changing that line. Those limits are now written down in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ sets one.
   supports a range of Python versions still passes.
 - A conformance rule that fails a workflow step running a command of its own instead of
   `pixi run <task>`, or naming a task nothing declares. The step list stays in one place,
-  so what CI runs and what your laptop runs cannot quietly stop being the same thing.
+  so the command CI runs is one you can run too.
 - `docs/template/index.md`, the page that says what the template ships and how to make a
   repo from it, and `mkdocs.template.yml`, which inherits `mkdocs.yml` and names the site
   after this repo while the shipped config keeps the placeholder. Both are template-only:
@@ -76,6 +76,19 @@ sets one.
   ['v20*']`, which CalVer versions can never match, now passes. The rule reads one path,
   `.github/workflows/release.yml`, and its own report says so: the same trigger under another
   filename is outside it.
+- The conformance rule about workflow steps now lets a step pass arguments to its task, after
+  `--`, and prints them on every run instead of failing. The clause that forbade them had no
+  failing fixture and was refuted by the fix it prescribed: moving the flag into a task of its
+  own passes the rule, so the divergence it named was already allowed through the compliant
+  path. A token after the task with no `--` still fails, because pixi reads it as its own
+  option, and so does a shell operator anywhere after the task. The list of pixi options that
+  take a separate value was measured off `pixi run --help` and had eight spellings of twelve
+  options, so `pixi run -p linux-64 build` — a step that literally is `pixi run <task>` — was
+  being told it ran a command.
+- `ci.yml`'s header no longer says CI and a laptop cannot drift. The rule reads the `run:` line
+  and nothing else, so `env:`, `working-directory:`, `shell:` and a local composite action can
+  each change what a step does without changing that line. Those limits are now written down in
+  the rule rather than implied away.
 - `conformance` now exits 2 when it could not run at all: no `.git`, no `pyproject.toml`, or
   a `pyproject.toml` it cannot read. It still exits 1 when it ran and a rule failed, and 0
   when every rule passed. Both used to exit 1, so a bad checkout looked just like a repo that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ sets one.
 
 ### Changed
 
+- The conformance rule about the publishing trigger now reads a tag filter instead of refusing
+  every one. A `push:` with no branch filter and a `create:` still fail, because an absent
+  filter is every ref and neither has a correct form. A `tags:` or `tags-ignore:` filter is
+  read, and it fails only where it lets the first-day `v0.0.0` tag through — so `tags:
+  ['v20*']`, which CalVer versions can never match, now passes. The rule reads one path,
+  `.github/workflows/release.yml`, and its own report says so: the same trigger under another
+  filename is outside it.
 - `conformance` now exits 2 when it could not run at all: no `.git`, no `pyproject.toml`, or
   a `pyproject.toml` it cannot read. It still exits 1 when it ran and a rule failed, and 0
   when every rule passed. Both used to exit 1, so a bad checkout looked just like a repo that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ sets one.
 - A conformance rule that fails a publishing workflow a tag push can trigger, and the
   workflow reader it is built on: the check now parses every workflow file, its triggers
   and its steps, instead of only reading text.
+- A conformance rule that fails a repo where a second resolver has been set up: a
+  `poetry.lock`, `uv.lock`, `pdm.lock` or `Pipfile` anywhere in the tree, or a `[tool.poetry]`,
+  `[tool.uv]` or `[tool.pdm]` table in `pyproject.toml`. Two resolvers can disagree quietly,
+  and what one of them installs is not what the gate runs in.
 - A conformance rule for the Python version. The pixi pin has to meet the
   `requires-python` floor, and any tool that writes a language level down has to write that
   floor. It checks that the declarations agree, and does not count them, so a repo that
@@ -58,6 +62,13 @@ sets one.
 
 ### Changed
 
+- The conformance rule about a second resolver now looks for four things instead of eight: a
+  `poetry.lock`, `uv.lock`, `pdm.lock` or `Pipfile`, and the three tables that configure those
+  resolvers. It no longer says anything about `requirements.txt`, `environment.yml`, `setup.py`
+  or `.pre-commit-config.yaml`, each of which was measured failing a repo doing correct work —
+  a notebook that runs on Colab needs a requirements file and cannot run pixi, and the old
+  advice was to delete it. The four that remain are files a resolver writes for itself, and
+  they now fail wherever they sit rather than only at the top of the repo.
 - The conformance rule about the publishing trigger now reads a tag filter instead of refusing
   every one. A `push:` with no branch filter and a `create:` still fail, because an absent
   filter is every ref and neither has a correct form. A `tags:` or `tags-ignore:` filter is

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,8 +5,11 @@ Write the docstring; this page follows.
 
 ## The examples are tests
 
-Give every public object an `Examples` block. `pixi run check` runs those blocks, so an
-example that no longer matches its code fails the tests.
+`pixi run check` runs the `Examples` blocks in `src/newpkg/`, so an example that no longer
+matches its code fails the tests.
+
+Write one where it makes the object easier to use, and leave it out where it would not.
+An example nobody keeps up to date is worse than none.
 
 Keep an example cheap, offline and deterministic. It has to give the same answer on any
 machine, with no network. A line that cannot do that needs `# doctest: +SKIP` at the end of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,17 @@ reportMissingParameterType = "none"
 # `src` is collected for its docstring examples alone: `--doctest-modules` runs them, so an
 # example that has drifted from the code it documents fails.
 testpaths = ["tests", "src"]
-addopts = ["-ra", "--strict-markers", "--strict-config", "--doctest-modules"]
+# `--continue-on-collection-errors` because collecting `src` IMPORTS every module in it. A
+# module needing an absent optional dependency — a plotting path, a CUDA path, a
+# platform-specific binding — used to abort collection and run zero tests. It now costs one
+# error. Measured: the run still exits non-zero, and a drifted example still fails (#66).
+addopts = [
+    "-ra",
+    "--strict-markers",
+    "--strict-config",
+    "--doctest-modules",
+    "--continue-on-collection-errors",
+]
 xfail_strict = true
 filterwarnings = ["error"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,12 +153,19 @@ venv = "default"
 # No `pythonVersion`: taken from the interpreter in the environment above.
 typeCheckingMode = "standard"
 # Not redundant: `standard` does not check that a parameter is annotated at all. `Any`
-# satisfies it, so the fix is always in the file you are editing.
+# satisfies it, so the fix is always in the file you are editing. Scoped off `tests/` below.
 reportMissingParameterType = "error"
 # Deliberately NOT `reportUnknownParameterType`: it also fails annotated parameters and
 # inferred return types whose types an untyped dependency owns. Not a bar a lab repo can meet.
 useLibraryCodeForTypes = true
 reportMissingTypeStubs = "none"
+
+# `tests/` back to plain `standard`. A fixture's type is pytest's, not the author's, and a
+# test signature promises a caller nothing: the rule fired four times on twenty lines of
+# correct test code and caught nothing (#65). `src` keeps it. Do not delete this block.
+[[tool.pyright.executionEnvironments]]
+root = "tests"
+reportMissingParameterType = "none"
 
 # ============================== pytest ==============================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ pyyaml = "*"
 
 [tool.pixi.feature.test.dependencies]
 pytest = "*"
+# Declared here too, not inherited: the tests run conformance, and a test environment shaped
+# differently from this one would import-error on every test.
+pyyaml = "*"
 
 # Exact: at 0.0.x nothing promises the next patch is compatible.
 [tool.pixi.feature.docs.dependencies]

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -41,6 +41,7 @@ gate that fires on nothing looks identical to a gate that passes.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import posixpath
 import re
 import shlex
@@ -115,6 +116,10 @@ WORKFLOW_SUFFIXES = (".yml", ".yaml")
 #: and the repo cannot publish at all. `init-repo` also deletes it by this exact path. Rules 8 and
 #: 9 both read it, so the name is written here once and nowhere else.
 RELEASE_WORKFLOW = f"{WORKFLOW_DIR}release.yml"
+
+#: The tag `init_repo.py` creates on a repo's opening day, and the one ref rule 9 asks about. A
+#: trigger that admits it runs the publishing workflow before anyone has decided to release.
+FIRST_TAG = "v0.0.0"
 
 #: Vale's spelling of on and off. Both forms appear in the wild; the gate accepts either.
 VALE_ON = {"YES", "TRUE", "ON"}
@@ -1088,27 +1093,69 @@ def rule_repo_shape(repo: Repo) -> Result:
     return result
 
 
-def _tag_push_events(workflow: Workflow) -> list[str]:
-    """List the triggers in one workflow that pushing a tag can fire, spelled as they are written.
+def _matches(patterns: Any, ref: str) -> bool | None:
+    """Whether a GitHub ref filter matches one ref, or ``None`` where it cannot be read.
 
-    Three of them, and only the first is the one people think of:
+    The filter syntax is `fnmatch` plus a leading `!` that excludes, and the LAST pattern to
+    match decides. That is the whole of the semantics and the whole of this function.
 
-    - `push:` with a `tags:` or `tags-ignore:` filter — the trigger written on purpose.
-    - `push:` naming no branch filter at all. An absent filter is not "no refs", it is EVERY
-      ref, so a bare `push:` fires on a tag exactly as it fires on a branch. `paths:` narrows
-      which files, never which refs.
+    The two places the dialects differ cannot change this answer for `FIRST_TAG`. GitHub's `*`
+    stops at a `/` where `fnmatch`'s does not, and `v0.0.0` has no `/`. GitHub's `+` is a
+    quantifier that `fnmatch` reads as a literal `+`, which can only turn a match into a miss —
+    and a miss is the answer that lets a workflow through, never the one that fails a correct
+    one.
+
+    ``None`` is what a caller cannot clear a workflow on: a filter written as something other
+    than strings is one this cannot read, and every caller reads that as the hazard.
+    """
+    if isinstance(patterns, str):
+        patterns = [patterns]
+    if not isinstance(patterns, list) or not patterns:
+        return None
+    matched = False
+    for pattern in patterns:  # pyright: ignore[reportUnknownVariableType]
+        if not isinstance(pattern, str):
+            return None
+        if fnmatch.fnmatchcase(ref, pattern.removeprefix("!")):
+            matched = not pattern.startswith("!")
+    return matched
+
+
+def _first_tag_events(workflow: Workflow) -> list[str]:
+    """List the triggers in one workflow that pushing `FIRST_TAG` fires, spelled as written.
+
+    Two of them are the same mistake — an absent filter is not "no refs", it is EVERY ref — and
+    they have no legitimate form, so they are listed whenever they appear:
+
+    - `push:` naming no branch filter at all, which fires on a tag exactly as on a branch.
+      `paths:` narrows which files, never which refs.
     - `create`, which fires on a branch or a tag coming into existence, and a pushed tag is a
       tag coming into existence.
 
-    A `push:` that names `branches:` or `branches-ignore:` is a branch trigger and is absent
-    from this list: naming any branch filter is what stops tags reaching the workflow.
+    A `tags:` or `tags-ignore:` filter is the other shape, and it is a DECISION rather than an
+    accident: someone wrote down which tags reach this workflow. So it is READ, not refused, and
+    listed only where it lets `FIRST_TAG` through. Under CalVer `vYYYY.M.PATCH` a filter like
+    `tags: ['v20*']` cannot match `v0.0.0`, and such a workflow is not listed here.
+
+    A `push:` that names `branches:` or `branches-ignore:` and no tag filter is a branch trigger
+    and is absent from this list: naming any branch filter is what stops tags reaching it.
     """
     fired: list[str] = []
     if "push" in workflow.triggers:
         config = workflow.triggers["push"]
         config = config if isinstance(config, dict) else {}
-        if "tags" in config or "tags-ignore" in config:
-            fired.append("`on: push:` names `tags:`")
+        if "tags" in config:
+            # Read even where `branches:` is also written: the two filters are a union, so a
+            # branch filter beside a tag filter narrows nothing about tags.
+            if _matches(config["tags"], FIRST_TAG) is not False:
+                fired.append(f"`on: push:` has a `tags:` filter that admits `{FIRST_TAG}`")
+        elif "tags-ignore" in config:
+            # The same call inverted. `tags-ignore:` fires on every tag its list does NOT match,
+            # so the hazard is gone only where the list provably matches `FIRST_TAG`.
+            if _matches(config["tags-ignore"], FIRST_TAG) is not True:
+                fired.append(
+                    f"`on: push:` has a `tags-ignore:` filter that does not exclude `{FIRST_TAG}`"
+                )
         elif not ("branches" in config or "branches-ignore" in config):
             fired.append("`on: push:` names no branch filter, so it fires on every ref, tags too")
     if "create" in workflow.triggers:
@@ -1117,23 +1164,34 @@ def _tag_push_events(workflow: Workflow) -> list[str]:
 
 
 def rule_release_trigger(repo: Repo) -> Result:
-    """9. Nothing a tag push fires can trigger the publishing workflow."""
+    """9. Nothing a `FIRST_TAG` push fires can trigger the publishing workflow.
+
+    KNOWN LIMIT, stated rather than closed: this reads one path, `RELEASE_WORKFLOW`, so the same
+    trigger in a workflow under any other name is outside the rule and `git mv` clears it. The
+    path is not a guess — a package index binds its trusted publisher to a workflow FILENAME, so
+    renaming the file is a change to external configuration and not a way around a check — but a
+    repo that publishes under another name is a repo this rule says nothing about. Closing that
+    would mean reading every workflow's steps for whatever action publishes, which is a list
+    nobody can keep, on every repo made from here. The narrow rule is the honest one.
+    """
     result = Result()
     publishing = [w for w in repo.workflows if w.path == RELEASE_WORKFLOW]
     if not publishing:
         result.notes.append(
-            f"not checked: no {RELEASE_WORKFLOW}, so this repo publishes to no package index"
+            f"not checked: no {RELEASE_WORKFLOW}. This rule reads that one path — the filename a "
+            "package index binds a trusted publisher to — so a publishing workflow under any "
+            "other name is outside it"
         )
         return result
     for workflow in publishing:
-        for fired in _tag_push_events(workflow):
+        for fired in _first_tag_events(workflow):
             result.problems.append(
                 _problem(
                     f"{workflow.path} can be triggered by a tag push: {fired}",
-                    "publishing is the one act in this toolchain that cannot be undone — a "
-                    "version can be neither unpublished nor reused — and `init-repo` pushes a "
-                    "first tag on a repo's opening day, so this trigger publishes from a repo "
-                    "nobody has finished naming",
+                    f"`init-repo` pushes `{FIRST_TAG}` on a repo's opening day and a "
+                    "`git push --tags` pushes every tag at once, so this trigger runs the "
+                    "publishing workflow with nobody having decided to release anything. "
+                    "Publishing a GitHub Release is that decision, written down",
                     "trigger it on `release:` with `types: [published]`, which is a person "
                     "publishing a GitHub Release on purpose, and add `workflow_dispatch:` for "
                     "re-running one that failed",
@@ -1504,8 +1562,9 @@ RULES: tuple[Rule, ...] = (
     Rule(
         9,
         "release-trigger",
-        f"{RELEASE_WORKFLOW} is triggered by publishing a GitHub Release and by nothing a tag "
-        "push fires — not `push: tags:`, not a `push:` with no branch filter, not `create`",
+        f"{RELEASE_WORKFLOW} names no trigger a `{FIRST_TAG}` push fires — not a `push:` with no "
+        "branch filter, not `create`, and not a `tags:` filter that admits it. A tag filter that "
+        f"cannot match `{FIRST_TAG}` is read and allowed; this rule reads that one path only",
         rule_release_trigger,
     ),
     Rule(

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -170,45 +170,51 @@ _SKILL_DIR_RES = (
 
 @dataclass(frozen=True)
 class SecondToolchain:
-    """One toolchain other than pixi, and where it would declare a dependency version.
+    """One resolver other than pixi, and where it leaves the environment it resolved.
 
     Attributes
     ----------
     tool
         The tool named in the failure, and listed in the note that says what was looked for.
-    path
-        A regex FULL-matched against a repo-relative tracked path. A pattern with no `/` in it
-        therefore matches at the repo root and nowhere else, which is where a resolver reads:
-        `tests/fixtures/requirements.txt` is a test's input, not this repo's dependencies.
+    name
+        A regex FULL-matched against a tracked path's FILE NAME, so a marker is found wherever
+        it sits. Un-anchored on purpose: `env/poetry.lock` resolves the same environment
+        `poetry.lock` does, and anchoring at the root would have made `git mv` the fix.
     table
-        A dotted table in `pyproject.toml`, for a tool that declares versions in the manifest
-        instead of a file of its own — a second build backend's dependency section.
+        A dotted table in `pyproject.toml`, for a resolver configured in the manifest rather
+        than in a file of its own.
     """
 
     tool: str
-    path: str = ""
+    name: str = ""
     table: str = ""
 
 
-#: Every second place a dependency version can be declared. Rule 10 reads this and nothing else,
-#: so covering one more tool is one more line here.
+#: Every marker of a second resolver. Rule 10 reads this and nothing else, so covering one more
+#: resolver is one more line here.
 #:
 #: It is a constant and not a `[tool.liulab.*]` key because it is not a claim a repo makes about
 #: itself: the rule is the same in every Liu Lab repo, and a repo that must keep one of these has
 #: `[tool.liulab.waived]`, which is printed on every run. A manifest list could be emptied
 #: instead, and an escape hatch nobody can see is the thing this file exists to prevent.
 #:
-#: Lockfiles are named per tool, never `*.lock`: `pixi.lock` is the lock this rule protects.
-#: `setup.cfg` is absent because it commonly carries only tool configuration and no dependency.
+#: One category and nothing wider: a competing resolver's GENERATED artifact, or the table that
+#: configures it. Each has no legitimate form, no human reader, and no sensible use in a
+#: subdirectory. Lockfiles are named per tool, never `*.lock`, because `pixi.lock` is the lock
+#: this rule protects.
+#:
+#: Four markers were measured firing on correct work and are gone. `requirements.txt`, because a
+#: notebook a researcher runs on Colab needs one and cannot run pixi. `environment.yml`, because
+#: `binder/environment.yml` is how a repo ships a runnable notebook. `setup.py`, because it
+#: builds C extensions while declaring no dependency at all. `.pre-commit-config.yaml`, because
+#: the hook shape a Liu Lab repo would write — `language: system`, `entry: pixi run lint` — pins
+#: nothing and is the pattern that REMOVES the drift this rule names. Telling a researcher to
+#: delete any of them is advice that breaks working science.
 SECOND_TOOLCHAINS: tuple[SecondToolchain, ...] = (
-    SecondToolchain("pre-commit", path=r"\.pre-commit-config\.ya?ml"),
-    SecondToolchain("pip", path=r"[^/]*requirements[^/]*\.txt|requirements/[^/]+\.txt"),
-    SecondToolchain("conda", path=r"[^/]*environment[^/]*\.ya?ml"),
-    SecondToolchain("pipenv", path=r"Pipfile(\.lock)?"),
-    SecondToolchain("setuptools", path=r"setup\.py"),
-    SecondToolchain("poetry", path=r"poetry\.lock", table="tool.poetry"),
-    SecondToolchain("uv", path=r"uv\.lock", table="tool.uv"),
-    SecondToolchain("pdm", path=r"pdm\.lock", table="tool.pdm"),
+    SecondToolchain("poetry", name=r"poetry\.lock", table="tool.poetry"),
+    SecondToolchain("uv", name=r"uv\.lock", table="tool.uv"),
+    SecondToolchain("pdm", name=r"pdm\.lock", table="tool.pdm"),
+    SecondToolchain("pipenv", name=r"Pipfile(\.lock)?"),
 )
 
 
@@ -1203,22 +1209,34 @@ def rule_release_trigger(repo: Repo) -> Result:
 
 
 def rule_single_toolchain(repo: Repo) -> Result:
-    """10. No second toolchain is configured: pixi and the manifest are the only ones."""
+    """10. No competing resolver has been run here: pixi and the manifest are the only ones.
+
+    A LOCKFILE or a resolver's table, and nothing wider. The rule was cut back to that category
+    after four of its eight markers were measured firing on correct work — a Colab notebook's
+    `requirements.txt`, a `binder/environment.yml`, a `setup.py` that builds a C extension and
+    declares no dependency, and a pre-commit hook that only invokes `pixi run`. Each of those is
+    a file someone reads or a build someone needs, and the rule's advice for all four was to
+    delete it.
+
+    It says nothing about a root `requirements.txt` any more, not even a warning. A researcher
+    whose notebook runs on Colab needs that file, cannot run pixi as the kernel, and would get
+    nothing from being told about it on every run.
+    """
     result = Result()
     # One why for every marker, because it is one failure: the class, not the tool.
     why = (
-        "two resolvers can disagree, and it fails silently rather than loudly: a version "
-        "declared here is one `pixi.lock` never sees, so an environment built from it and the "
-        "environment the gate runs in differ while both look correct. pyproject.toml is the "
-        "single source of truth for dependencies, environments and tasks"
+        "a second resolver is set up to build this repo's environment, and it resolves against "
+        "its own inputs: what it installs and what the gate runs in can differ while both look "
+        "correct, and nothing reports it. pyproject.toml is the single source of truth for "
+        "dependencies, environments and tasks, and pixi.lock is the only lock read here"
     )
     for marker in SECOND_TOOLCHAINS:
-        if marker.path:
+        if marker.name:
             for rel in repo.tracked:
-                if re.fullmatch(marker.path, rel):
+                if re.fullmatch(marker.name, PurePosixPath(rel).name):
                     result.problems.append(
                         _problem(
-                            f"{rel} declares dependencies for {marker.tool}, a second toolchain",
+                            f"{rel} belongs to {marker.tool}, a resolver other than pixi",
                             why,
                             f"delete {rel} and declare what it pinned in pyproject.toml — "
                             "`[tool.pixi.dependencies]` for a package, `[tool.pixi.tasks]` for a "
@@ -1235,11 +1253,11 @@ def rule_single_toolchain(repo: Repo) -> Result:
                 )
             )
     # This rule is never vacuous — the list is always there and so is the manifest — but a run
-    # still has to say WHICH second toolchains it knew to look for, or a green means nothing.
+    # still has to say WHICH resolvers it knew to look for, or a green means nothing.
     names = ", ".join(marker.tool for marker in SECOND_TOOLCHAINS)
     result.notes.append(
-        f"{len(SECOND_TOOLCHAINS)} second toolchain(s) looked for across "
-        f"{len(repo.tracked)} tracked path(s) and pyproject.toml: {names}"
+        f"{len(SECOND_TOOLCHAINS)} competing resolver(s) looked for anywhere in "
+        f"{len(repo.tracked)} tracked path(s) and in pyproject.toml: {names}"
     )
     return result
 
@@ -1570,8 +1588,9 @@ RULES: tuple[Rule, ...] = (
     Rule(
         10,
         "single-toolchain",
-        "no second toolchain is configured — no pre-commit config, requirements file, conda "
-        "environment or foreign resolver's table declares a version the pixi lock never sees",
+        "no competing resolver is set up here — no poetry.lock, uv.lock, pdm.lock or Pipfile "
+        "anywhere in the tree, and no [tool.poetry], [tool.uv] or [tool.pdm] in pyproject.toml. "
+        "A generated artifact of another resolver, and nothing a person reads or writes",
         rule_single_toolchain,
     ),
     Rule(

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -103,6 +103,13 @@ DEFAULT_DOCS_DIR = "docs"
 #: site from one docs tree: a second configuration `INHERIT`s the first and APPENDS to its nav,
 #: and the navbar the build renders carries the entries of both. A repo with one configuration
 #: reads one, and this costs nothing.
+#:
+#: Every one of them INCLUDING a local overlay no task builds, which is the known cost. Reading
+#: instead only the configurations a declared docs task names with `-f` was considered and
+#: declined: pixi writes a task as a string, as `{cmd = "..."}` or as a list, so it needs a second
+#: command-line parser beside rule 12's, and it would stop reading a configuration built by a
+#: Makefile or a workflow rather than by a task. A rule that reads one file too many is the
+#: cheaper error here.
 _SITE_CONFIG_RE = re.compile(r"^mkdocs(?:\..+)?\.ya?ml$")
 
 #: Where GitHub reads workflows, and the two file endings it accepts. Nothing below this
@@ -398,15 +405,23 @@ class SiteConfig:
         Whether the file has a `nav:` key at all. A configuration with none is not one whose nav
         is empty — the generator builds the navbar from the directory tree instead — so a rule
         reports it as unchecked rather than green.
+    generators
+        The page-generating plugins this file declares, along `INHERIT`, in name order. A
+        configuration with one builds pages nothing tracks, so its nav cannot be resolved
+        against a checkout at all.
     targets
-        Repo-relative path -> the nav string that named it, for every entry that names a page
-        rather than a link or a bare anchor.
+        Repo-relative path -> the nav string that named it, for every entry that names a page.
+    unresolved
+        The entries that name no page and no link — a directory, an `...` — as written. Not a
+        problem and not a target: the rule says it did not resolve them.
     """
 
     path: str
     docs_dir: str
     declares_nav: bool
+    generators: tuple[str, ...]
     targets: dict[str, str]
+    unresolved: tuple[str, ...]
 
 
 @dataclass
@@ -462,13 +477,12 @@ class Repo:
             loaded = None
         return loaded if isinstance(loaded, dict) else {}
 
-    def resolved_docs_dir(self, rel: str) -> str:
-        """One configuration's site source, resolved along the `INHERIT` chain.
+    def inherit_chain(self, rel: str) -> Iterator[dict[str, Any]]:
+        """One configuration and every one it `INHERIT`s, nearest first.
 
-        Walked rather than read from the one file, because a configuration that inherits another
-        and declares no `docs_dir` of its own uses the parent's, and reading only the child would
-        resolve its nav against a directory that is not the site source. `INHERIT` is a path
-        relative to the configuration that writes it.
+        `INHERIT` is a path relative to the configuration that writes it. Anything a child does
+        not declare it takes from the parent, so a rule reading the child alone reads half a
+        configuration.
 
         The visited set is not defensive clutter: a cycle is a configuration nobody can build, and
         it must not be a conformance crash either.
@@ -477,14 +491,33 @@ class Repo:
         while rel not in seen:
             seen.add(rel)
             document = self.config(rel)
+            yield document
+            parent = document.get("INHERIT")
+            if not isinstance(parent, str):
+                return
+            rel = posixpath.normpath(posixpath.join(posixpath.dirname(rel), parent))
+
+    def resolved_docs_dir(self, rel: str) -> str:
+        """One configuration's site source, resolved along the `INHERIT` chain.
+
+        Walked rather than read from the one file, because a configuration that inherits another
+        and declares no `docs_dir` of its own uses the parent's, and reading only the child would
+        resolve its nav against a directory that is not the site source.
+        """
+        for document in self.inherit_chain(rel):
             declared = document.get("docs_dir")
             if isinstance(declared, str):
                 return posixpath.normpath(declared).strip("/")
-            parent = document.get("INHERIT")
-            if not isinstance(parent, str):
-                break
-            rel = posixpath.normpath(posixpath.join(posixpath.dirname(rel), parent))
         return DEFAULT_DOCS_DIR
+
+    def page_generators(self, rel: str) -> tuple[str, ...]:
+        """Every page-generating plugin one configuration declares, along the `INHERIT` chain.
+
+        Walked for the same reason the site source is: a child that inherits a parent declaring
+        `gen-files` builds the same generated pages, and its own nav names them.
+        """
+        declared = {name for document in self.inherit_chain(rel) for name in _plugins(document)}
+        return tuple(sorted(declared & PAGE_GENERATORS))
 
     @cached_property
     def mkdocs(self) -> dict[str, Any]:
@@ -499,7 +532,8 @@ class Repo:
     @cached_property
     def nav(self) -> dict[str, str]:
         """Repo-relative path -> the `mkdocs.yml` nav entry that names it."""
-        return _nav_targets(self.docs_dir, self.mkdocs.get("nav"))
+        targets, _ = _nav_targets(self.docs_dir, self.mkdocs.get("nav"))
+        return targets
 
     @cached_property
     def site_configs(self) -> tuple[SiteConfig, ...]:
@@ -515,6 +549,12 @@ class Repo:
         other's dead entry, and a rule merging them into a single nav would have to know which
         file won; the union needs neither, because an entry is checked where it was written. A
         repo with one configuration reads one, and this costs nothing.
+
+        The join is ZENSICAL's: it merges an inherited configuration with `deepmerge`'s
+        `always_merger`, which CONCATENATES lists. mkdocs' own `INHERIT` replaces them, so a repo
+        that takes ADR 0001's fallback back to mkdocs has a child nav that wins outright — and
+        the union then checks entries no build renders. It would report a dead entry in a file
+        that is no longer read, which is a false failure. Revisit this with the generator.
         """
         found: list[SiteConfig] = []
         for rel in self.tracked:
@@ -522,12 +562,15 @@ class Repo:
                 continue
             document = self.config(rel)
             docs_dir = self.resolved_docs_dir(rel)
+            targets, unresolved = _nav_targets(docs_dir, document.get("nav"))
             found.append(
                 SiteConfig(
                     path=rel,
                     docs_dir=docs_dir,
                     declares_nav="nav" in document,
-                    targets=_nav_targets(docs_dir, document.get("nav")),
+                    generators=self.page_generators(rel),
+                    targets=targets,
+                    unresolved=unresolved,
                 )
             )
         return tuple(found)
@@ -606,9 +649,33 @@ def _walk_strings(node: Any) -> Iterator[str]:
 #: is a file that can be missing. The scheme half is what covers `mailto:`, which has no `//`.
 _NAV_LINK_RE = re.compile(r"^[a-z][a-z0-9+.\-]*:|^//|^#", re.IGNORECASE)
 
+#: The anchor a nav entry may carry — `guide.md#install` names `guide.md`, and the anchor is a
+#: place on it. A bare `#top` never reaches this, being a link by the rule above.
+_ANCHOR_RE = re.compile(r"#.*$")
 
-def _nav_targets(docs_dir: str, nav: Any) -> dict[str, str]:
-    """Repo-relative path -> the `nav:` entry that named it, for one site configuration.
+#: What a nav entry has to end in to name a PAGE. Markdown, a notebook where the repo has the
+#: plugin that renders one, and an HTML file the builder passes through.
+#:
+#: An entry ending in anything else names something this cannot resolve and must not guess at:
+#: `- API: reference/` is a directory `literate-nav` expands, `- ...` is `awesome-pages` asking
+#: for the rest of the tree. Both were measured failing rule 13, and the fix it printed for the
+#: second — "add docs/..." — is what a rule looks like outside its domain. A typo is unaffected:
+#: `hnad.md` still ends in `.md`.
+PAGE_SUFFIXES = (".md", ".ipynb", ".html")
+
+#: The plugins that WRITE PAGES into the site source while the build runs. A nav entry naming one
+#: of them resolves to nothing a checkout carries, so rule 13 has no premise in a repo that
+#: declares one and reports itself vacuous instead.
+#:
+#: That replaces a waiver, and the difference is the point. Waivers are per RULE, which is right
+#: for an all-or-nothing rule and wrong for this one: a repo with a single generated section had
+#: to turn rule 13 off for every hand-written entry it exists to protect, and the waiver then
+#: swallowed the genuine dead links too — measured, two problems suppressed where one was real.
+PAGE_GENERATORS = frozenset({"gen-files", "literate-nav", "awesome-pages", "macros"})
+
+
+def _nav_targets(docs_dir: str, nav: Any) -> tuple[dict[str, str], tuple[str, ...]]:
+    """One configuration's nav, read apart: the pages it names, and the entries that name none.
 
     Nav paths are relative to `docs_dir`, so they are prefixed with it before they can be compared
     with anything `git ls-files` said. Getting that wrong is not a false negative that shows up
@@ -617,13 +684,41 @@ def _nav_targets(docs_dir: str, nav: Any) -> dict[str, str]:
     Rules 2 and 13 read the same mapping, so what counts as a nav path is decided once. `normpath`
     is what lets rule 13 see an entry reaching ABOVE the site source: `../README.md` under `docs/`
     arrives here as `README.md`, outside the directory the builder copies.
+
+    The second half is everything that is neither a link nor a page — the entries a rule should
+    say it did not resolve rather than report as missing.
     """
     targets: dict[str, str] = {}
+    unresolved: list[str] = []
     for raw in _walk_strings(nav):
         if _NAV_LINK_RE.match(raw):
             continue
-        targets[posixpath.normpath(f"{docs_dir or '.'}/{raw}")] = raw
-    return targets
+        path = _ANCHOR_RE.sub("", raw)
+        if not path.endswith(PAGE_SUFFIXES):
+            unresolved.append(raw)
+            continue
+        targets[posixpath.normpath(f"{docs_dir or '.'}/{path}")] = raw
+    return targets, tuple(unresolved)
+
+
+def _plugins(document: dict[str, Any]) -> set[str]:
+    """Every plugin name one site configuration declares.
+
+    Both spellings: a LIST, whose items are bare names or single-key mappings carrying options,
+    and a MAPPING of name to options. A theme-namespaced name — `material/search` — is that
+    theme's copy of the plugin, so the last segment is the name.
+    """
+    declared = document.get("plugins")
+    names: list[Any] = []
+    if isinstance(declared, list):
+        for item in declared:  # pyright: ignore[reportUnknownVariableType]
+            if isinstance(item, str):
+                names.append(item)
+            elif isinstance(item, dict):
+                names.extend(item)  # pyright: ignore[reportUnknownArgumentType]
+    elif isinstance(declared, dict):
+        names.extend(declared)  # pyright: ignore[reportUnknownArgumentType]
+    return {str(name).rsplit("/", 1)[-1] for name in names}
 
 
 def _task_names(node: Any) -> Iterator[str]:
@@ -1490,12 +1585,15 @@ def rule_workflow_step_tasks(repo: Repo) -> Result:
 
 
 def rule_nav_target_exists(repo: Repo) -> Result:
-    """13. Every `nav:` entry names a tracked page under that configuration's site source.
+    """13. Every `nav:` entry that names a page names a tracked one, under the site source.
 
-    TRACKED and not merely present, because CI builds from a checkout. The one shape that
-    legitimately fails is a repo GENERATING pages into the site source at build time, whose
-    entries name nothing this can see; `[tool.liulab.waived]` is the answer there, and it is
-    printed on every run so the choice stays visible.
+    TRACKED and not merely present, because CI builds from a checkout.
+
+    Two shapes are outside it rather than waived. An entry that names no page at all — a
+    directory, an `...` — is reported unresolved, because a rule that cannot tell what a menu
+    item points at cannot say the page is missing. And a configuration declaring a plugin that
+    WRITES pages during the build has no premise here at all: nothing it names is in a checkout,
+    so the rule reports itself vacuous rather than failing every generated entry.
     """
     result = Result()
     if not repo.site_configs:
@@ -1513,6 +1611,17 @@ def rule_nav_target_exists(repo: Repo) -> Result:
             result.notes.append(
                 f"not checked: {config.path} declares no `nav:`, so the site builds its navbar "
                 "from the directory tree and names no page for this rule to resolve"
+            )
+            continue
+        # A page-generating plugin is the shape that used to need a waiver. The pages it writes
+        # exist after the build and never in the checkout this reads, so the rule has no premise
+        # rather than a repo to fail — and saying so leaves the waiver table free for a decision
+        # somebody actually made.
+        if config.generators:
+            result.notes.append(
+                f"not checked: {config.path} declares {', '.join(config.generators)}, which "
+                "writes pages into the site source while the build runs, so a nav entry may name "
+                "a page no checkout carries"
             )
             continue
         prefix = f"{config.docs_dir}/" if config.docs_dir not in {"", "."} else ""
@@ -1555,6 +1664,13 @@ def rule_nav_target_exists(repo: Repo) -> Result:
         result.notes.append(
             f"{config.path}: {len(config.targets)} nav entry(s) against {prefix or 'the repo root'}"
         )
+        # Said out loud rather than passed over. These are the entries the rule declined to
+        # resolve, and a reader who expected one of them to be checked should find out here.
+        if config.unresolved:
+            result.notes.append(
+                f"{config.path}: {len(config.unresolved)} nav entry(s) name no page and were not "
+                f"resolved: {', '.join(config.unresolved)}"
+            )
     return result
 
 
@@ -1686,9 +1802,11 @@ RULES: tuple[Rule, ...] = (
     Rule(
         13,
         "nav-target-exists",
-        "every `nav:` entry in every tracked site configuration names a tracked file under that "
-        "configuration's site source. This is the one broken site the generator does not validate "
-        "at all — it builds green, reports no issues, and publishes a menu item that 404s",
+        "every `nav:` entry that names a page — `.md`, `.ipynb`, `.html` — names a tracked one "
+        "under that configuration's site source. This is the one broken site the generator does "
+        "not validate at all: it builds green, reports no issues, and publishes a menu item that "
+        "404s. An entry naming no page, and a configuration whose plugins write pages during the "
+        "build, are reported unchecked rather than failed",
         rule_nav_target_exists,
     ),
     Rule(

--- a/scripts/conformance.py
+++ b/scripts/conformance.py
@@ -130,23 +130,42 @@ VALE_OFF = {"NO", "FALSE", "OFF"}
 PIXI_RUN = "pixi run"
 TASK_TABLE = "[tool.pixi.tasks]"
 
-#: The `pixi run` options that take a SEPARATE value, so the token after one is that value and
-#: never the task name. The `--option=value` form needs no entry, being one token. Anything else
-#: beginning with `-` is read as a switch, so an option pixi grows later would be mistaken for the
-#: task and reported LOUDLY — the safe direction of error for a check whose whole job is to notice
-#: drift nobody announced.
+#: Every `pixi run` option that takes a SEPARATE value, so the token after one is that value and
+#: never the task name. Both spellings of each, because a workflow writes either. The
+#: `--option=value` form needs no entry, being one token.
+#:
+#: READ OFF `pixi run --help`, at pixi 0.71.2, and not guessed. A missing spelling is not a safe
+#: error: the option's value is mistaken for the task, and a step that literally is
+#: `pixi run -p linux-64 build` is told it runs a command rather than `pixi run <task>`. That
+#: shipped — the list held eight spellings of the twelve options pixi has. Re-measure when the
+#: pixi version moves, and add both spellings of anything new.
 PIXI_VALUE_OPTIONS = frozenset(
     {
         "-e",
         "--environment",
+        "-p",
+        "--platform",
+        "-m",
         "--manifest-path",
+        "-w",
+        "--workspace",
         "--color",
         "--auth-file",
+        "--config-file",
+        "--pinning-strategy",
         "--pypi-keyring-provider",
+        "--tls-root-certs",
         "--concurrent-solves",
         "--concurrent-downloads",
     }
 )
+
+#: What separates a task from the arguments passed to it, and the tokens that are not arguments
+#: at all. pixi reads a bare `--durations=10` as its own option and refuses to run, so a step
+#: passing one without the separator is broken before this rule sees it. A shell operator after
+#: the task starts a second command, which is the drift rule 12 is about.
+ARGUMENT_SEPARATOR = "--"
+SHELL_OPERATORS = frozenset({"&&", "||", "|", ";", "&"})
 
 #: What a `${{ ... }}` expression is replaced by before a step's command is split into tokens.
 #: GitHub substitutes these when the job runs, and `shlex` would split one into three tokens and
@@ -622,18 +641,40 @@ def _task_names(node: Any) -> Iterator[str]:
             yield from _task_names(value)
 
 
-def _invoked_task(run: str) -> str | None:
+@dataclass(frozen=True)
+class Invocation:
+    """One `pixi run` command line, read apart.
+
+    Attributes
+    ----------
+    task
+        The task name — the first token that is neither an option nor an option's value.
+    arguments
+        Whatever the step passes to that task after `--`, empty for most steps. Kept rather
+        than discarded because rule 12 prints them: an argument only CI passes is a legitimate
+        thing to write and a thing a reader should be able to see without opening the workflow.
+    """
+
+    task: str
+    arguments: tuple[str, ...]
+
+
+def _invoked_task(run: str) -> Invocation | None:
     """Read the pixi task one step's `run:` script invokes, or ``None`` when it runs a command.
 
-    The accepted shape is `pixi run`, any pixi options, and one more token — the task. Options are
-    skipped on both sides of `run`, so `pixi run -e test test` and `pixi run docs-build` arrive
-    the same way and no spelling is privileged.
+    The accepted shape is `pixi run`, any pixi options, the task, and then — optionally — `--`
+    and arguments for it. Options are skipped on both sides of `run`, so `pixi run -e test test`
+    and `pixi run docs-build` arrive the same way and no spelling is privileged.
 
-    Nothing may follow the task, and that is the strict half of the rule rather than an oversight.
-    A step passing arguments of its own is the drift this rule is about, one level down: the
-    arguments a task runs with belong in the task, which is exactly where `check-static` keeps its
-    own list. A script of several lines, or two commands joined by `&&`, leaves tokens after the
-    task and lands here too.
+    Arguments are ACCEPTED and reported, not forbidden. A flag a workflow wants and a laptop does
+    not — `--durations=10` on the CI run of the test suite — is ordinary, and forbidding it only
+    moves the divergence into a second task definition, where nothing checks it against the first.
+    What the rule can still say is that the command came from the task table.
+
+    Two shapes are still not this one. Tokens after the task that do not start with `--`: pixi
+    would read them as its own options and refuse to run, so the step is broken already. And a
+    shell operator anywhere after the task — `pixi run build && rm -rf dist` is two commands, and
+    the second one is what no `pixi run` does. A script of several lines lands here too.
     """
     script = _EXPRESSION_RE.sub(EXPRESSION, run)
     try:
@@ -647,9 +688,15 @@ def _invoked_task(run: str) -> str | None:
     if index >= len(tokens) or tokens[index] != "run":
         return None
     index = _skip_options(tokens, index + 1)
-    if len(tokens) - index != 1:
+    if index >= len(tokens):
         return None
-    return tokens[index]
+    task, rest = tokens[index], tokens[index + 1 :]
+    if rest and rest[0] != ARGUMENT_SEPARATOR:
+        return None
+    arguments = rest[1:]
+    if any(token in SHELL_OPERATORS for token in arguments):
+        return None
+    return Invocation(task=task, arguments=tuple(arguments))
 
 
 def _skip_options(tokens: list[str], index: int) -> int:
@@ -1362,7 +1409,22 @@ def rule_python_version_agreement(repo: Repo) -> Result:
 
 
 def rule_workflow_step_tasks(repo: Repo) -> Result:
-    """12. Every workflow step that runs anything invokes a task the manifest declares."""
+    """12. Every workflow step that runs anything invokes a task the manifest declares.
+
+    What this verifies is that the command a step runs is DECLARED — its text lives in the task
+    table, where a person can read it and a laptop can run it. It is not a guarantee that CI and
+    a laptop run the same thing, and it was once written down as one. The known limits, none of
+    them closed here:
+
+    - only the `run:` line is read. `env:` at any of three scopes, `working-directory:`, `shell:`
+      and `--manifest-path` all change what a step does without changing that line;
+    - a step that `uses:` a local composite action runs whatever that action's steps run, and
+      reading those means parsing `.github/actions/**`;
+    - a task may pass arguments after `--`. They are printed in the notes rather than forbidden.
+
+    Closing any of them means parsing foreign files in a check that ships to every lab repo, for
+    a guarantee no wording here can make true. Say the limits instead.
+    """
     result = Result()
     # `uses:` steps are not examined at all, and that is the rule and not an exemption: an action
     # is a dependency the workflow pulls in, not a step of this repo's own build, and there is no
@@ -1372,41 +1434,53 @@ def rule_workflow_step_tasks(repo: Repo) -> Result:
         result.notes.append("not checked: no tracked workflow has a step that runs a command")
         return result
     unresolved = 0
+    passing: list[str] = []
     for step in running:
         where = f"{step.workflow} job `{step.job}` step {step.index}"
         if step.name:
             where += f" ({step.name})"
-        task = _invoked_task(step.run or "")
-        if task is None:
+        invocation = _invoked_task(step.run or "")
+        if invocation is None:
             result.problems.append(
                 _problem(
                     f"{where} runs a command rather than `{PIXI_RUN} <task>`",
-                    "the step list lives in the task table so that CI and a laptop run the same "
-                    "steps by construction. A step that spells out a command runs something no "
+                    "the step list lives in the task table so that what CI runs is something a "
+                    "laptop can run too. A step that spells out a command runs something no "
                     "local `pixi run` does, and both stay green while they quietly stop being the "
                     "same claim — until someone notices the two lists disagree, months later",
-                    f"declare what it runs as a task in {TASK_TABLE}, arguments included, and "
-                    f"make the step `{PIXI_RUN} <that task>`",
+                    f"declare what it runs as a task in {TASK_TABLE} and make the step "
+                    f"`{PIXI_RUN} <that task>`. An argument only CI passes goes after "
+                    f"`{ARGUMENT_SEPARATOR}`",
                 )
             )
-        elif EXPRESSION in task:
+            continue
+        if invocation.arguments:
+            passing.append(f"{where} -> {shlex.join(invocation.arguments)}")
+        if EXPRESSION in invocation.task:
             unresolved += 1
-        elif task not in repo.tasks:
+        elif invocation.task not in repo.tasks:
             result.problems.append(
                 _problem(
-                    f"{where} invokes `{task}`, which this repo declares no task by",
+                    f"{where} invokes `{invocation.task}`, which this repo declares no task by",
                     "a step naming a task nobody declared cannot run at all, and the workflow "
                     "that finds out is often one that runs rarely — the publish, the scheduled "
                     "job — so the break surfaces on the day it costs the most. It reads as if it "
                     "were following the convention, which is what makes it worse than a command",
-                    f"declare `{task}` in pyproject.toml under {TASK_TABLE}, or point the step at "
-                    "a task that is declared",
+                    f"declare `{invocation.task}` in pyproject.toml under {TASK_TABLE}, or point "
+                    "the step at a task that is declared",
                 )
             )
     result.notes.append(
         f"{len(running)} step(s) that run a command, across {len(repo.workflows)} workflow(s), "
         f"against {len(repo.tasks)} declared task(s)"
     )
+    # Printed on every run that has one, green runs included. An argument a workflow passes and a
+    # laptop does not is a real difference between the two, and the rule no longer forbids it —
+    # so the one thing left to do about it is make it visible without opening the workflow.
+    if passing:
+        result.notes.append(
+            f"{len(passing)} step(s) pass arguments to their task: {'; '.join(passing)}"
+        )
     if unresolved:
         result.notes.append(
             f"{unresolved} step(s) name their task with a `" + EXPRESSION + "` expression, which "
@@ -1603,9 +1677,10 @@ RULES: tuple[Rule, ...] = (
     Rule(
         12,
         "workflow-step-tasks",
-        f"every workflow step that runs a command invokes a declared task — `{PIXI_RUN} <task>` "
-        f"and nothing else, with the task in {TASK_TABLE}, so the step list cannot drift from the "
-        "one a laptop runs. A step that `uses:` an action is not a step of this repo's build",
+        f"every workflow step that runs a command invokes a declared task — `{PIXI_RUN} <task>`, "
+        f"with the task in {TASK_TABLE}, so the command CI runs is one a laptop can run too. "
+        f"Arguments are allowed after `{ARGUMENT_SEPARATOR}` and printed in the notes; a shell "
+        "operator is not an argument. A step that `uses:` an action is not a step of this build",
         rule_workflow_step_tasks,
     ),
     Rule(

--- a/skills/template-dev/SKILL.md
+++ b/skills/template-dev/SKILL.md
@@ -34,6 +34,12 @@ why the identity keys ship carrying the placeholder rather than a real URL; `ini
 fills them from the git remote. Writing the real identity in looks like a fix and quietly
 removes the only check that a derived repo's published site points at itself.
 
+A derived repo will bring you findings. Some are gifts — a defect this repo is too young to
+exercise. Some are a downstream need in general clothing, and correctness will not separate
+them; who pays will. A rule lands in every repo made from here, including ones that never
+have the problem. `AGENTS.md` carries the rest of that test, and it binds hardest on a rule
+someone else is asking for.
+
 `AGENTS.md` is generic on purpose too. It ships with a sentinel line telling the reader to
 run `/init`, and `init-repo` leaves it alone. Nothing in it points at this skill, which is
 the whole reason this guidance is a skill and not a `CONTRIBUTING.md`: a skill is

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -34,6 +34,13 @@ REPO = Path(__file__).resolve().parents[1]
 CONFORMANCE = REPO / "scripts" / "conformance.py"
 INSTALLER = REPO / "skills" / "install.py"
 
+# Rule 7 delegates to the installer above, and a repo that took `conformance.py` without the
+# skills lane ships none. There the rule is vacuous — `--`, with the note saying why — and the
+# tree it reports on has no skills to count. Every expectation that turns on this reads these two
+# names, so the module runs in such a repo instead of erroring in setup.
+SYMLINKS_STATUS = "ok" if INSTALLER.exists() else "--"
+SYMLINKS_NOTE = "1 skill" if INSTALLER.exists() else "not checked: no skills/install.py"
+
 # Spelled in two pieces for the same reason `conformance.py` spells it that way: `init-repo`
 # substitutes the placeholder through the whole tree and the dogfood job then greps a rendered
 # repo for it. A literal here would be rewritten, and would be found.
@@ -186,9 +193,11 @@ def repo(tmp_path: Path) -> Path:
     write(root, "docs/adr/0001-a-decision.md", f"{FRONT_MATTER}# A decision\n\nWe chose this.\n")
     write(root, "docs/research/a-note.md", f"{FRONT_MATTER}# A note\n\nWhat was found.\n")
     # The real installer, not a stand-in: rule 7 delegates to this file, so a copy of it is what
-    # makes the delegation the thing under test.
-    (root / "skills").mkdir(parents=True, exist_ok=True)
-    shutil.copy(INSTALLER, root / "skills" / "install.py")
+    # makes the delegation the thing under test. Conditional because a repo that has no installer
+    # to copy is exactly the repo rule 7 has to stay vacuous in.
+    if INSTALLER.exists():
+        (root / "skills").mkdir(parents=True, exist_ok=True)
+        shutil.copy(INSTALLER, root / "skills" / "install.py")
     subprocess.run(["git", "init", "-q"], cwd=root, check=True)
     return root
 
@@ -277,8 +286,8 @@ def test_a_tree_that_has_skills_passes_every_rule(repo: Path) -> None:
     verdicts = statuses(proc)
     assert verdicts["skill-file-location"] == "ok"
     assert verdicts["skill-name-prefix"] == "ok"
-    assert verdicts["skill-symlinks"] == "ok"
-    assert "1 skill" in proc.stdout
+    assert verdicts["skill-symlinks"] == SYMLINKS_STATUS
+    assert SYMLINKS_NOTE in flat(proc.stdout)
 
 
 # The exit status is a three-way answer and not a boolean, so all three are asserted here rather
@@ -470,17 +479,18 @@ def test_rule_5_fires_on_a_skill_file_the_installer_cannot_see(repo: Path) -> No
 
 
 def test_rule_6_fires_on_a_skill_that_shadows_the_shared_plugin(repo: Path) -> None:
-    # Correctly installed in both discovery paths, so rule 7 is green and the NAME is the only
-    # thing wrong — which is the point: this one is invisible to every other check.
+    # Correctly installed in both discovery paths, so rule 7 does not fail and the NAME is the
+    # only thing wrong — which is the point: this one is invisible to every other check.
     add_skill(repo, "lab-hpc")
     proc = conformance(repo)
     assert proc.returncode == 1
     verdicts = statuses(proc)
     assert verdicts["skill-name-prefix"] == "FAIL"
-    assert verdicts["skill-symlinks"] == "ok"
+    assert verdicts["skill-symlinks"] == SYMLINKS_STATUS
     assert "is a repo-local skill named `lab-hpc`" in proc.stderr
 
 
+@pytest.mark.skipif(not INSTALLER.exists(), reason="repo ships no skills/install.py")
 def test_rule_7_delegates_to_the_installer(repo: Path) -> None:
     # A skill with no symlinks. The assertion is not just that rule 7 fails but that the
     # installer's OWN report comes through, fix line included — proof the rule delegates rather

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -728,70 +728,101 @@ def test_every_failure_is_reported_and_not_just_the_first(repo: Path) -> None:
     assert "3 of 13 rules failed" in proc.stderr
 
 
-def test_rule_10_fires_on_a_pre_commit_configuration(repo: Path) -> None:
-    write(repo, ".pre-commit-config.yaml", "repos:\n  - repo: local\n    hooks: []\n")
+@pytest.mark.parametrize(
+    ("rel", "tool"),
+    [
+        ("poetry.lock", "poetry"),
+        ("uv.lock", "uv"),
+        ("pdm.lock", "pdm"),
+        ("Pipfile", "pipenv"),
+        ("Pipfile.lock", "pipenv"),
+    ],
+)
+def test_rule_10_fires_on_a_competing_resolvers_artifact(repo: Path, rel: str, tool: str) -> None:
+    write(repo, rel, "# resolved elsewhere\n")
     proc = conformance(repo)
     assert proc.returncode == 1
     assert statuses(proc)["single-toolchain"] == "FAIL"
-    assert ".pre-commit-config.yaml declares dependencies for pre-commit" in proc.stderr
+    assert f"{rel} belongs to {tool}, a resolver other than pixi" in proc.stderr
     assert "pyproject.toml is the single source of truth" in flat(proc.stderr)
 
 
-def test_rule_10_fires_on_a_requirements_file(repo: Path) -> None:
-    # Not `requirements.txt`: the marker covers the family, and a rule written for the one
-    # spelling one repo happened to use would pass this tree.
-    write(repo, "requirements-dev.txt", "ruff==0.6.0\n")
+def test_rule_10_fires_on_a_competing_resolvers_artifact_in_a_subdirectory(repo: Path) -> None:
+    # UN-ANCHORED, and that is the rule: `env/uv.lock` resolves the same environment `uv.lock`
+    # does. Anchoring at the root would have made `git mv` the fix and taught people to hide the
+    # thing the rule exists to find.
+    write(repo, "env/uv.lock", "version = 1\n")
     proc = conformance(repo)
     assert proc.returncode == 1
     assert statuses(proc)["single-toolchain"] == "FAIL"
-    assert "requirements-dev.txt declares dependencies for pip" in proc.stderr
+    assert "env/uv.lock belongs to uv" in proc.stderr
 
 
-def test_rule_10_fires_on_a_conda_environment_file(repo: Path) -> None:
-    write(repo, "environment.yml", "name: example\ndependencies:\n  - python=3.13\n")
-    proc = conformance(repo)
-    assert proc.returncode == 1
-    assert statuses(proc)["single-toolchain"] == "FAIL"
-    assert "environment.yml declares dependencies for conda" in proc.stderr
-
-
-def test_rule_10_fires_on_a_second_build_backends_dependency_section(repo: Path) -> None:
-    # No file of its own: the versions are a table in the same manifest, which is the shape a
+@pytest.mark.parametrize("table", ["tool.poetry", "tool.uv", "tool.pdm"])
+def test_rule_10_fires_on_a_competing_resolvers_table(repo: Path, table: str) -> None:
+    # No file of its own: the resolver is configured in the same manifest, which is the shape a
     # rule that only looked at filenames would miss.
-    write(repo, "pyproject.toml", PYPROJECT + '\n[tool.poetry.dependencies]\nrequests = "*"\n')
+    write(repo, "pyproject.toml", PYPROJECT + f"\n[{table}]\nmanaged = true\n")
     proc = conformance(repo)
     assert proc.returncode == 1
     assert statuses(proc)["single-toolchain"] == "FAIL"
-    assert "pyproject.toml has [tool.poetry], which configures poetry" in proc.stderr
+    assert f"pyproject.toml has [{table}], which configures" in proc.stderr
 
 
-def test_rule_10_fires_on_another_resolvers_lockfile(repo: Path) -> None:
-    write(repo, "uv.lock", "version = 1\n")
-    proc = conformance(repo)
-    assert proc.returncode == 1
-    assert statuses(proc)["single-toolchain"] == "FAIL"
-    assert "uv.lock declares dependencies for uv" in proc.stderr
-
-
-def test_rule_10_leaves_the_pixi_lock_and_a_fixture_alone(repo: Path) -> None:
-    # `pixi.lock` is the lock this rule protects, and a requirements file BELOW the root is some
-    # test's input, not this repo's dependencies. Markers are named per tool and root-anchored so
-    # that neither of these is a failure.
-    write(repo, "pixi.lock", "version: 6\n")
-    write(repo, "tests/fixtures/requirements.txt", "requests==2.0.0\n")
+@pytest.mark.parametrize(
+    "rel",
+    [
+        # A notebook a researcher runs on Colab, which cannot run pixi as its kernel.
+        "requirements.txt",
+        "requirements-frozen.txt",
+        # How a repo ships a runnable notebook, byte-identical wherever it sits.
+        "environment.yml",
+        "binder/environment.yml",
+        # Builds a C extension and declares no dependency at all.
+        "setup.py",
+    ],
+)
+def test_rule_10_leaves_correct_work_alone(repo: Path, rel: str) -> None:
+    # Every one of these was measured failing the wider rule, which told the author to delete the
+    # file and declare it in a conda table their notebook cannot see. A measurement outranks the
+    # defect a wider marker might also have caught.
+    write(repo, rel, "scanpy==1.10\n")
     proc = conformance(repo)
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert statuses(proc)["single-toolchain"] == "ok"
 
 
-def test_rule_10_says_which_second_toolchains_it_looked_for(repo: Path) -> None:
+def test_rule_10_leaves_a_pre_commit_hook_alone(repo: Path) -> None:
+    # Dropped rather than narrowed. pre-commit is a hook runner, not a resolver, and the shape a
+    # Liu Lab repo would write pins nothing and REMOVES the drift the rule names.
+    write(
+        repo,
+        ".pre-commit-config.yaml",
+        "repos:\n  - repo: local\n    hooks:\n      - id: lint\n        name: lint\n"
+        "        language: system\n        entry: pixi run lint\n",
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["single-toolchain"] == "ok"
+
+
+def test_rule_10_leaves_the_pixi_lock_alone(repo: Path) -> None:
+    # `pixi.lock` is the lock this rule protects, so markers are named per resolver and never
+    # `*.lock`.
+    write(repo, "pixi.lock", "version: 6\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["single-toolchain"] == "ok"
+
+
+def test_rule_10_says_which_resolvers_it_looked_for(repo: Path) -> None:
     # This rule can never be vacuous, so it never prints `--`. It still has to say what it knew
     # to look for, or its green means only that nothing on an unstated list was found.
     proc = conformance(repo)
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert statuses(proc)["single-toolchain"] == "ok"
-    assert "8 second toolchain(s) looked for" in flat(proc.stdout)
-    assert "pre-commit, pip, conda, pipenv, setuptools, poetry, uv, pdm" in flat(proc.stdout)
+    assert "4 competing resolver(s) looked for anywhere in" in flat(proc.stdout)
+    assert "poetry, uv, pdm, pipenv" in flat(proc.stdout)
 
 
 def pyproject_python(

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1258,6 +1258,94 @@ def test_rule_13_does_not_flag_a_link_or_an_anchor(repo: Path) -> None:
     assert "mkdocs.yml: 2 nav entry(s) against docs/" in flat(proc.stdout)
 
 
+def test_rule_13_does_not_flag_an_entry_that_names_no_page(repo: Path) -> None:
+    # `- ...` is awesome-pages asking for the rest of the tree, not a file. The old rule resolved
+    # it to `docs/...` and told the reader to add that, which is what a rule looks like outside
+    # its domain. It is reported as unresolved instead, so a reader who expected it to be checked
+    # finds out here rather than believing it was.
+    write(repo, "mkdocs.yml", MKDOCS + "  - ...\n  - Generated: reference/\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "ok"
+    assert "2 nav entry(s) name no page and were not resolved: ..., reference/" in flat(proc.stdout)
+
+
+def test_rule_13_still_fires_on_a_typo_beside_an_entry_that_names_no_page(repo: Path) -> None:
+    # The narrowing must not cost the rule its subject. `reference/` is passed over and `hnad.md`
+    # is not, because a typo still ends in `.md` — and this tree needed a waiver before, which
+    # would have suppressed both.
+    write(repo, "mkdocs.yml", MKDOCS + "  - API: reference/\n  - Typo: hnad.md\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["nav-target-exists"] == "FAIL"
+    assert "nav entry `hnad.md` names docs/hnad.md, which is not tracked" in proc.stderr
+    # One problem, not two: the entry naming no page contributed none.
+    assert "nav-target-exists FAIL 1 problem(s)" in flat(proc.stdout)
+
+
+def test_rule_13_is_vacuous_where_a_plugin_writes_pages_during_the_build(repo: Path) -> None:
+    # The shape that used to need a waiver on first contact. Waivers are per RULE, so a repo with
+    # one generated section turned rule 13 off for every hand-written entry it exists to protect
+    # — measured, two problems suppressed where one was a real dead link. The rule has no premise
+    # here, and saying so leaves the waiver table for a decision somebody actually made.
+    write(
+        repo,
+        "mkdocs.yml",
+        "site_name: example\n"
+        "plugins:\n"
+        "  - search\n"
+        "  - gen-files:\n"
+        "      scripts: [docs/gen_ref.py]\n"
+        "nav:\n"
+        "  - Home: index.md\n"
+        "  - API: reference/SUMMARY.md\n",
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "--"
+    assert "not checked: mkdocs.yml declares gen-files" in flat(proc.stdout)
+
+
+def test_rule_13_reads_the_mapping_spelling_of_plugins(repo: Path) -> None:
+    # `plugins:` is a list of names, or a mapping of name to options. A reader that knew one
+    # spelling would fail every generated entry in a repo that wrote the other — the false
+    # failure this narrowing exists to remove, back again through the parser.
+    write(
+        repo,
+        "mkdocs.yml",
+        "site_name: example\n"
+        "plugins:\n"
+        "  literate-nav:\n"
+        "    nav_file: SUMMARY.md\n"
+        "nav:\n"
+        "  - Home: index.md\n"
+        "  - API: reference/SUMMARY.md\n",
+    )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "--"
+    assert "not checked: mkdocs.yml declares literate-nav" in flat(proc.stdout)
+
+
+def test_rule_13_strips_an_anchor_before_resolving_a_page(repo: Path) -> None:
+    # `api.md#install` names `api.md`, at a place on it. The whole string is not a path and never
+    # was, so the old rule reported `docs/api.md#install` missing while the page was right there.
+    write(repo, "mkdocs.yml", MKDOCS + "  - Install: api.md#install\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["nav-target-exists"] == "ok"
+    assert "mkdocs.yml: 2 nav entry(s) against docs/" in flat(proc.stdout)
+
+
+def test_rule_13_fires_on_a_missing_page_named_with_an_anchor(repo: Path) -> None:
+    # Stripping the anchor is what keeps this one checked: the page is what has to be there.
+    write(repo, "mkdocs.yml", MKDOCS + "  - Ghost: ghost.md#gone\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["nav-target-exists"] == "FAIL"
+    assert "nav entry `ghost.md#gone` names docs/ghost.md, which is not tracked" in proc.stderr
+
+
 def test_rule_13_fires_on_a_page_that_exists_but_sits_outside_the_site_source(repo: Path) -> None:
     # The second class, and the reason it is the same rule rather than a separate concern:
     # `README.md` really is there, so a check that only asked whether the file exists would call

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -529,14 +529,71 @@ def test_rule_8_is_satisfied_and_not_merely_skipped_when_both_premises_hold(repo
     assert statuses(proc)["repo-shape"] == "ok"
 
 
-def test_rule_9_fires_on_a_publishing_workflow_triggered_by_a_tag_push(repo: Path) -> None:
+def test_rule_9_fires_on_a_tag_filter_that_admits_the_first_tag(repo: Path) -> None:
     publishes(repo, "on:\n  push:\n    tags: ['v*']\n")
     proc = conformance(repo)
     assert proc.returncode == 1
     assert statuses(proc)["release-trigger"] == "FAIL"
-    assert f"{RELEASE_YML} can be triggered by a tag push: `on: push:` names `tags:`" in proc.stderr
-    assert "cannot be undone" in flat(proc.stderr)  # the rule and the fix, not a rewritten assert
+    assert (
+        f"{RELEASE_YML} can be triggered by a tag push: `on: push:` has a `tags:` filter that "
+        "admits `v0.0.0`" in proc.stderr
+    )
+    # The why has to be true of every tree it prints on, so it names the first-day tag rather
+    # than irreversibility: this rule also prints on a release.yml that publishes no package.
+    assert "pushes `v0.0.0` on a repo's opening day" in flat(proc.stderr)
     assert "trigger it on `release:` with `types: [published]`" in flat(proc.stderr)
+
+
+@pytest.mark.parametrize(
+    "tags",
+    [
+        # CalVer is `vYYYY.M.PATCH`, so neither of these can match `v0.0.0` at all.
+        "['v20*']",
+        "['v[1-9]*']",
+        # The exclusion written out, which is a decision and not an accident.
+        "['v*', '!v0.0.0']",
+    ],
+)
+def test_rule_9_allows_a_tag_filter_that_cannot_match_the_first_tag(repo: Path, tags: str) -> None:
+    # The measured misfire this rule was narrowed to remove. A filter someone wrote down is read,
+    # not refused, and a filter that excludes the hazard by construction has nothing to fix.
+    publishes(repo, f"on:\n  push:\n    tags: {tags}\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["release-trigger"] == "ok"
+
+
+def test_rule_9_allows_a_tags_ignore_that_excludes_the_first_tag(repo: Path) -> None:
+    publishes(repo, "on:\n  push:\n    tags-ignore: ['v0.0.0']\n")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["release-trigger"] == "ok"
+
+
+def test_rule_9_fires_on_a_tags_ignore_that_leaves_the_first_tag_through(repo: Path) -> None:
+    # The same call inverted: this fires on every tag but `v9.*`, `v0.0.0` included.
+    publishes(repo, "on:\n  push:\n    tags-ignore: ['v9.*']\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["release-trigger"] == "FAIL"
+    assert "`tags-ignore:` filter that does not exclude `v0.0.0`" in proc.stderr
+
+
+def test_rule_9_reads_a_tag_filter_it_cannot_parse_as_admitting_the_first_tag(repo: Path) -> None:
+    # Conservative, and the one direction that has to be: a filter this cannot read is not a
+    # filter it can clear a workflow on.
+    publishes(repo, "on:\n  push:\n    tags:\n      - pattern: v*\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["release-trigger"] == "FAIL"
+
+
+def test_rule_9_reads_the_tag_filter_even_beside_a_branch_filter(repo: Path) -> None:
+    # `branches:` and `tags:` in one `push:` are a union, so a branch filter narrows no tags.
+    publishes(repo, "on:\n  push:\n    branches: [main]\n    tags: ['v*']\n")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["release-trigger"] == "FAIL"
 
 
 def test_rule_9_fires_on_a_push_with_no_branch_filter(repo: Path) -> None:
@@ -584,9 +641,22 @@ def test_rule_9_is_vacuous_and_not_passing_when_the_repo_publishes_nothing(repo:
     proc = conformance(repo)
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert statuses(proc)["release-trigger"] == "--"
-    assert f"not checked: no {RELEASE_YML}, so this repo publishes to no package index" in flat(
-        proc.stdout
+    assert f"not checked: no {RELEASE_YML}" in flat(proc.stdout)
+
+
+def test_rule_9_says_it_reads_one_path_and_the_rename_that_leaves_it(repo: Path) -> None:
+    # The known limit, stated where someone meets it rather than closed with a content sniffer:
+    # the same trigger under another filename is outside this rule, and the vacuous run says so.
+    write(
+        repo,
+        ".github/workflows/publish.yml",
+        "name: publish\non:\n  push:\n    tags: ['v*']\njobs:\n  build:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n      - run: pixi run build\n",
     )
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["release-trigger"] == "--"
+    assert "a publishing workflow under any other name is outside it" in flat(proc.stdout)
 
 
 def test_warning_14_warns_about_the_sentinel_and_does_not_fail(repo: Path) -> None:

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1066,6 +1066,53 @@ def test_rule_12_fires_on_a_command_chained_onto_a_task(repo: Path) -> None:
     assert "step 1 runs a command rather than `pixi run <task>`" in proc.stderr
 
 
+def test_rule_12_passes_a_step_that_hands_arguments_to_its_task(repo: Path) -> None:
+    # The shape a sibling repo was told to stop writing: a flag CI wants and a laptop does not.
+    # Putting it in a second task instead passes this rule too, so forbidding it here moved the
+    # divergence into the task table rather than removing it. Accepted, and PRINTED — which is
+    # the whole of what the rule can still do about it.
+    runs(repo, "pixi run -e test test -- --durations=10")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "ok"
+    assert "1 step(s) pass arguments to their task" in flat(proc.stdout)
+    assert "job `check` step 1 -> --durations=10" in flat(proc.stdout)
+
+
+def test_rule_12_reads_past_a_platform_flag_to_the_task(repo: Path) -> None:
+    # `-p` takes a separate value, so a rule that did not know the spelling would read `linux-64`
+    # as the task and tell a step that literally is `pixi run <task>` that it runs a command. The
+    # option list is read off `pixi run --help` for that reason, and a missing entry is a false
+    # failure rather than a safe one. Building for a cluster platform is ordinary here.
+    runs(repo, "pixi run -p linux-64 build")
+    proc = conformance(repo)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert statuses(proc)["workflow-step-tasks"] == "ok"
+    assert "1 step(s) that run a command" in flat(proc.stdout)
+
+
+def test_rule_12_fires_on_a_token_after_the_task_with_no_separator(repo: Path) -> None:
+    # `build` is declared, and `extra` is not an argument pixi would pass to it: pixi reads what
+    # follows the task as its own, so this step is broken before conformance sees it. The `--`
+    # is what makes an argument an argument.
+    runs(repo, "pixi run build extra")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    assert "step 1 runs a command rather than `pixi run <task>`" in proc.stderr
+    assert "An argument only CI passes goes after `--`" in flat(proc.stderr)
+
+
+def test_rule_12_fires_on_a_command_chained_after_the_separator(repo: Path) -> None:
+    # Arguments are allowed; a second command is not, and `--` does not launder one. Without this
+    # the separator would be the way around the rule rather than the way to satisfy it.
+    runs(repo, "pixi run -e test test -- --durations=10 && rm -rf dist")
+    proc = conformance(repo)
+    assert proc.returncode == 1
+    assert statuses(proc)["workflow-step-tasks"] == "FAIL"
+    assert "step 1 runs a command rather than `pixi run <task>`" in proc.stderr
+
+
 def test_rule_12_fires_on_a_multi_line_script(repo: Path) -> None:
     write(
         repo,


### PR DESCRIPTION
This session added five conformance rules and two code-path gates in a day. Asked whether that was
guarding the template's generalizability or just accumulating restriction, I audited. It was
accumulating. This reverses most of it and writes down the test that should have prevented it.

## The principle, written down

Nothing in the repo said a rule must earn its place, so nothing stopped rules arriving.

`AGENTS.md` gets a **Restraint** section — generalizable, lightweight, uncustomized, ahead of
thorough — with three questions before any gate lands, and the clause this session cost me:
**a measurement outranks a hypothesis.** A rule shown to fire on correct work loses to that
evidence, not to a defect it might also catch.

The `template-dev` skill gets the half that is only true here: a derived repo bringing a finding
may be handing over a gift or a downstream need in general clothing; correctness will not separate
them, **who pays will**. It points at `AGENTS.md` rather than restating it.

## What the audit measured

A competent 130-line module plus a 20-line test file produced **22 gate failures, none of them a
bug**. Every fix was a mechanical edit made to satisfy a checker.

| Rule | Fired on correct work | Now |
| --- | --- | --- |
| 9 `release-trigger` | `tags: ['v20*']` (cannot match `v0.0.0`); `tags-ignore: ['v0.0.0']`, an explicit defence | reads the filter with `fnmatch`; lists it only where it admits `v0.0.0` |
| 10 `single-toolchain` | a Colab `requirements.txt`; a zero-dependency `setup.py`; a `language: system` hook | 8 markers → 4, only a competing resolver's own files |
| 12 `workflow-step-tasks` | `pixi run test -- --durations=10`; `pixi run -p linux-64 build` | arguments allowed after `--`, printed in the notes every run |
| 13 `nav-target-exists` | `- ...`, `- API: reference/`, `page.md#anchor` | resolves only page targets; vacuous when a generator plugin is declared |
| `reportMissingParameterType` | every pytest fixture, `parametrize` arg, `*args`, inner function | scoped off `tests/`, where it caught nothing |
| doctests over `src/` | an absent optional dependency **aborted the suite, zero tests run** | one visible error instead |

Rule 11 `python-version-agreement` was audited and **kept unchanged** — it checks agreement rather
than counting, and the library-range case passes.

## Three findings that outrank the individual fixes

**Rule 12's warrant was refuted by its own prescribed fix.** I defended the no-arguments clause by
arguing that loosening would admit `-k slow`. Declaring `ci-test = "pytest -k slow --durations=10"`
as a task and invoking it as `pixi run ci-test` reports **ok** — the defect was already admitted,
through the compliant path the rule tells you to take. The clause also had **no test fixture**, so
by this repo's own standard it checked nothing that was defended.

**`dogfood` cannot detect over-restriction.** The over-strict version of every change here passed
it, because the rendered repos *are* the template. It proves a fresh repo still builds; it cannot
tell you a rule is burdensome. That is how twelve restrictions landed in one day with the gate
never objecting — and it is the same structural blind spot as the age-dependent defects found
earlier, pointed at cost instead of correctness.

**Narrowing made one rule stronger.** Un-anchoring rule 10's surviving markers closed the `git mv`
escape: `env/uv.lock` went from passing to failing. Aimed at the defect instead of at file names,
it is now less restrictive *and* harder to evade.

## Closed as not-planned, on verified premises

- **#61** `exclude_docs` — the key appears nowhere in the pinned generator, so nothing 404s. A rule
  premised on a setting that does nothing.
- **#60** the `env:` bypass — one of six (`env:` at three scopes, `working-directory:`, `shell:`,
  `--manifest-path`, a local composite action). Closing it takes six to five without restoring the
  property. Documented in the rule's docstring instead, and `ci.yml` no longer claims CI and a
  laptop cannot drift "by construction".

## One change that goes the other way

**#62** makes `tests/test_conformance.py` run in a repo with no `skills/`. Measured: **1 passed,
102 errors** before; **102 passed, 1 skipped** after, with the skill rules reporting vacuous. Proven
a no-op here — identical test count, identical node ids, byte-identical conformance output, and
`pixi.lock` unchanged.

## Known gap, deliberately not filed

`pyproject.toml` declares `typer>=0.12` twice — `[project]` and `[tool.pixi.dependencies]` —
hand-mirrored and cross-checked by nothing. That is exactly the drift rule 10's original message
claimed to prevent, living inside the file it blesses. Fixing it means *adding* a rule, on a change
dedicated to removing them. Recorded here so it stays a deliberate decision rather than something
smuggled in under an audit.

## Verification

`pixi run check` green (6 static steps, **108 tests**, up from 80 — the dropped markers' fixtures
were replaced with positive trees proving the correct work now passes). `pixi run docs-build` green.
`pixi run dogfood` green on all three shapes.

Closes #62, closes #63, closes #64, closes #65, closes #66, closes #67, closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZNsHzTC77n87dtoGiN581
