### PR TITLE
What liulab-protein taught the template: narrow two gates, drop a cap, hand over the repo settings, and ship a licence

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -18,6 +18,11 @@ globs:
 
 config:
   default: true
+  # Scoped, not disabled. A hard tab in prose is an accident; inside a fenced block it is the
+  # content — `docs/research/` quotes a tab-indented record verbatim, the reason `Lab.Jargon`,
+  # `Lab.Readability` and the agent-docs table already exempt it.
+  MD010:
+    code_blocks: false
   # The formatter owns line length in code and nothing owns it in prose. Wrapping is a
   # matter of taste, and tables and long links routinely exceed any limit, so MD013 would
   # fire on every one of them.

--- a/.vale.ini
+++ b/.vale.ini
@@ -17,8 +17,8 @@ Lab.Readability = YES
 Lab.LengthDoc = NO
 Lab.LengthAdr = NO
 
-# 2. Agent-facing: word budget only.
-[{AGENTS.md,CONTEXT.md,docs/agents/**/*.md,skills/**/SKILL.md}]
+# 2. Agent-facing: word budget only. CONTEXT.md is not here — see section 5.
+[{AGENTS.md,docs/agents/**/*.md,skills/**/SKILL.md}]
 BasedOnStyles = Lab
 Lab.Jargon = NO
 Lab.Readability = NO
@@ -36,6 +36,17 @@ Lab.LengthAdr = YES
 # 4. Research notes: uncapped, and exempt from jargon because a note quotes what it argues
 # against — the note defining the jargon map lists every banned phrase as evidence.
 [docs/research/**/*.md]
+BasedOnStyles = Lab
+Lab.Jargon = NO
+Lab.Readability = NO
+Lab.LengthDoc = NO
+Lab.LengthAdr = NO
+
+# 5. The glossary: no file cap. It grows one term at a time and never shrinks, so a file-level
+# word count measures the size of the domain, not the quality of the writing. Conformance caps
+# each entry at 200 words instead — the unit that matches how the file grows. Last because it
+# is the narrowest pattern here, and the later section wins.
+[CONTEXT.md]
 BasedOnStyles = Lab
 Lab.Jargon = NO
 Lab.Readability = NO

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ CONTEXT.md        the glossary — the words this repo uses
 bottom before fixing anything. The docs build is not part of `check`; it needs its own pixi
 environment and runs as its own CI job.
 
+Work on a branch and merge through a pull request: `pull_request` tests the merge commit,
+while a push to `main` tests it only once it has landed.
+
 ## Writing rules
 
 Three rules, all enforced by `vale`: be concise; agent-facing documents have word caps;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,11 +63,56 @@ environment and runs as its own CI job.
 Work on a branch and merge through a pull request: `pull_request` tests the merge commit,
 while a push to `main` tests it only once it has landed.
 
+Four traps in the gate:
+
+- **`--doctest-modules` runs every `Examples` block in `src/` as a test.** An example that
+  downloads, shells out or needs a large file wants `# doctest: +SKIP`, and the marker covers
+  only the example it sits on.
+- **`filterwarnings = ["error"]`.** Each tolerated warning gets a targeted entry in
+  `pyproject.toml` with a comment saying why. Never a blanket ignore.
+- **`src/` is collected**, so every module is imported at test time. Keep a heavy import
+  inside the method body that needs it, not at module scope.
+- **A substring of `--help` output is not a substring of the help.** Typer prints it through
+  rich, which styles the first dash of an option on its own, so `--version` is several spans
+  and not one string. Colour is off under `ssh` and on in CI; reproduce CI with
+  `FORCE_COLOR=1`, and strip the styling before you assert.
+
 ## Writing rules
 
 Three rules, all enforced by `vale`: be concise; agent-facing documents have word caps;
 human-facing prose avoids jargon and stays readable. Read `docs/agents/writing.md` before
 writing either kind — the caps are lower than you expect, and this file is subject to one.
+
+### Comments and docstrings are short
+
+Nothing checks these, so the rule is on you. A docstring says what a thing does and what it
+promises. A comment says why a line is surprising. Neither is a notebook.
+
+**Do not record:**
+
+- **Measurements.** Sizes, row counts, timings, percentages, entry totals. They were true
+  once, on one machine, against one release. A number in a comment is wrong by the next
+  release and nothing checks it.
+- **The environment.** Hostnames, absolute paths, package versions, which host something ran
+  on, what a tool printed that day.
+- **Implementation detail a reader can see.** Restating the code below in prose, or narrating
+  how the current version happens to work inside.
+- **History.** What a previous version did, what was tried, which ticket decided it, what the
+  alternative was.
+
+Where a fact genuinely has to survive, it has a home that is checked. A comment is the one
+place that holds none of them accountable, which is why it is the wrong place:
+
+| The fact | Where it lives |
+| --- | --- |
+| What the code does | a test pins it |
+| A decision and its trade-off | an ADR |
+| Vocabulary | `CONTEXT.md` |
+| What is still open | an issue |
+| A measurement | nowhere — delete it |
+
+Keep a docstring to its contract — arguments, return, what it raises, one example if the
+example earns its keep. Say the surprising thing in one sentence and stop.
 
 ## Read next
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Liu Lab
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/adr/0002-what-the-gate-does-not-check.md
+++ b/docs/adr/0002-what-the-gate-does-not-check.md
@@ -1,0 +1,45 @@
+---
+search:
+  exclude: true
+---
+
+# What the gate deliberately does not check
+
+Three additions a review of the first repo made from this template proposed, and this repo
+declined. Each rests on a reason the workflow files do not carry, so a later review would
+otherwise re-propose it.
+
+## `docs.yml` is not chained to `ci.yml`
+
+The site is already proved twice by the strict docs build — as the `docs` job on every pull
+request, and again inside `docs.yml` before the deploy — so a failing formatter or type check
+has never produced a broken page. What went red downstream was `fmt-check`, which says nothing
+about whether a page is correct.
+
+Chaining on a `workflow_run` event resolves both the workflow file and the default checkout
+from the default branch, so it must check out the triggering commit explicitly or silently
+publish a tree nothing tested. That is a foot-gun in a file every repo keeps forever, bought
+for a provenance gap whose worst observed outcome was a correctly built site. The branch
+ruleset — a pull request plus `check`, `test`, `build` and `docs` — is the fix instead.
+
+## `dogfood` gets no adversarial fixture corpus
+
+Every rendered rung carries this repo's own thin content, so `dogfood` proves that `init-repo`
+subtracts correctly and can never prove how a gate behaves on real material. A corpus would
+put material in this repo to catch what one configuration line catches, and it would then be
+material every rule here has to keep passing. `scripts/dogfood.py` names the limit in a
+comment instead.
+
+A gate's behaviour on real material is a question for a test that writes the material it
+needs and removes it again.
+
+## The `build` job stays in every shape
+
+Lab repos consume each other over `git+https`, and installing that way runs the build backend
+directly, so a broken build breaks every sibling's install. One job on every pull request buys
+that.
+
+Making the job mean more requires installing the wheel into a clean environment and resolving
+from declared metadata, which is networked; a no-deps install inside the environment already
+built would pass regardless. An expensive or networked check must never fail a normal pull
+request, so that check belongs in the consuming repo, on its own trigger.

--- a/docs/adr/0002-what-the-gate-does-not-check.md
+++ b/docs/adr/0002-what-the-gate-does-not-check.md
@@ -5,9 +5,13 @@ search:
 
 # What the gate deliberately does not check
 
-Three additions a review of the first repo made from this template proposed, and this repo
-declined. Each rests on a reason the workflow files do not carry, so a later review would
-otherwise re-propose it.
+Three additions to `liuhlab/liulab-repo-template`'s own gate, proposed by a review of the
+first repo made from it and declined here. Each rests on a reason the workflow files do not
+carry, so a later review would otherwise re-propose it.
+
+A record about this template is not about the repos made from it, so `init-repo` deletes this
+file along with ADR 0001 and the three research notes. A derived repo inherits the gate; the
+argument stays here.
 
 ## `docs.yml` is not chained to `ci.yml`
 

--- a/docs/agents/writing.md
+++ b/docs/agents/writing.md
@@ -9,8 +9,11 @@ Three rules. Two are checked by `vale` in `pixi run check`; the third is on you.
 
 ## 1. Be concise
 
-Shorter beats longer — in documents, issues, commit messages, and replies. If a sentence
-survives deletion without loss, delete it. The caps below are ceilings, not targets.
+Shorter beats longer — in documents, issues, commit messages, replies, and code. If a
+sentence survives deletion without loss, delete it. The caps below are ceilings, not targets.
+
+Code's share of this rule is its comments and docstrings, which no cap reaches. `AGENTS.md`
+says what belongs in one and where each fact lives when it does not.
 
 ## 2. Agent-facing documents have word caps
 

--- a/docs/agents/writing.md
+++ b/docs/agents/writing.md
@@ -16,13 +16,16 @@ survives deletion without loss, delete it. The caps below are ceilings, not targ
 
 | Files | Cap |
 | --- | --- |
-| `AGENTS.md`, `CONTEXT.md`, `docs/agents/*`, `skills/*/SKILL.md` | 1000 (`Lab.LengthDoc`) |
+| `AGENTS.md`, `docs/agents/*`, `skills/*/SKILL.md` | 1000 (`Lab.LengthDoc`) |
 | `docs/adr/*` | 400 (`Lab.LengthAdr`) |
+| `CONTEXT.md` | 200 words per glossary entry, checked by `conformance` |
 | `docs/research/*` | none — research notes are long by nature |
 
-`CONTEXT.md` is capped a second way: **200 words per glossary entry**, checked by
-`conformance`, not by vale. A glossary grows one term at a time, so the file is the wrong
-unit to measure.
+`CONTEXT.md` has no file cap. A glossary grows one term at a time and never shrinks, so a
+file-level count measures how big the domain is, not how well the entries are written — a cap
+set for fourteen terms fires again at sixteen. The per-entry cap is the unit that matches, and
+it is the only one. What can go wrong with a long glossary is the number of entries, which no
+word cap was going to catch.
 
 **Measure with the gate, not with `wc`.** `wc -w` counts table pipes, link targets and
 shell flags as words; vale does not, and vale is what enforces the cap. The gap scales with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,7 +204,7 @@ filterwarnings = ["error"]
 # globs; a trailing `/` matches a directory. Values name the Vale Length rule, or `false`.
 [tool.liulab.agent-docs]
 "AGENTS.md" = "LengthDoc"
-"CONTEXT.md" = "LengthDoc"
+"CONTEXT.md" = false          # capped per entry by conformance, not per file
 "docs/agents/" = "LengthDoc"
 "skills/" = "LengthDoc"
 "docs/adr/" = "LengthAdr"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,13 @@ src = ["src", "tests", "scripts"]
 # No `target-version`: ruff infers it from `requires-python`.
 extend-exclude = [".pixi", "site", "build", "dist"]
 
+# ruff formats Python code blocks inside Markdown, and `docs/research/` quotes sources verbatim —
+# the reason `Lab.Jargon`, `Lab.Readability` and the agent-docs table already exempt it. On the
+# formatter alone, so `ruff check`'s reach is unchanged. Narrow, not `*.md`: a fence in README.md
+# is an example a reader copies.
+[tool.ruff.format]
+exclude = ["docs/research/**"]
+
 [tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -70,6 +71,17 @@ TEMPLATE_ARTIFACTS = (
     "docs/template/index.md",
     "mkdocs.template.yml",
 )
+
+#: The two repo-settings commands `init-repo`'s closing checklist hands over, and the `ci.yml`
+#: jobs each shape keeps. Spelled out here rather than imported from `scripts/init_repo.py`, for
+#: the reason the constants above are: a check that reads its expectation out of the thing it is
+#: checking cannot tell a shape-correct list from one that drifted off the shapes.
+LABEL_COMMAND = "gh label clone liuhlab/liulab-repo-template --force --repo"
+SHAPE_CHECKS = {
+    "published": ["check", "test", "build", "docs"],
+    "not-published": ["check", "test", "build", "docs"],
+    "no-package": ["check", "docs"],
+}
 
 #: The `PIXI_*` variables a parent `pixi run` exports. They name the TEMPLATE's manifest, and a
 #: nested pixi that inherited them would check this repo instead of the rendered one.
@@ -118,14 +130,19 @@ RUNGS: tuple[Rung, ...] = (
 )
 
 
-def run(args: Sequence[str], cwd: Path, *, label: str) -> None:
-    """Run a command in a scratch repo, showing its output only when it fails."""
+def run(args: Sequence[str], cwd: Path, *, label: str) -> str:
+    """Run a command in a scratch repo, showing its output only when it fails.
+
+    Returns what it printed. Every caller but one discards that; `init_repo.py`'s is the closing
+    checklist, which is the only place the two repo-settings commands exist.
+    """
     env = {k: v for k, v in os.environ.items() if k not in PIXI_VARS}
     proc = subprocess.run(args, cwd=cwd, env=env, capture_output=True, text=True, check=False)
     if proc.returncode != 0:
         sys.stdout.write(proc.stdout)
         sys.stderr.write(proc.stderr)
         raise RenderError(f"{label} failed (exit {proc.returncode})")
+    return proc.stdout
 
 
 class RenderError(Exception):
@@ -251,6 +268,30 @@ def check_changelog(stage: Path) -> list[str]:
     ]
 
 
+def check_next_steps(rung: Rung, output: str) -> list[str]:
+    """Read the checklist `init_repo.py` printed: both repo-settings commands, filled in.
+
+    Neither one is in the tree, so no other check here can see them — the labels and the ruleset
+    are GitHub state, and the checklist is the part of that this repo owns. The required checks
+    are read back out of the command rather than matched as one literal string, because what
+    can drift is the LIST: `no-package` deletes the `test` and `build` jobs, and a ruleset
+    naming a job that never reports makes every pull request in that repo unmergeable.
+    """
+    problems: list[str] = []
+    slug = f"liuhlab/{rung.repo}"
+    if f"{LABEL_COMMAND} {slug}" not in output:
+        problems.append(f"the checklist does not hand over `{LABEL_COMMAND} {slug}`")
+    if f"repos/{slug}/rulesets" not in output:
+        problems.append(f"the checklist does not hand over a ruleset command for {slug}")
+    contexts = re.findall(r'"context":\s*"([^"]+)"', output)
+    if contexts != SHAPE_CHECKS[rung.shape]:
+        problems.append(
+            f"the ruleset command requires {contexts or 'nothing'}, "
+            f"and this shape has {SHAPE_CHECKS[rung.shape]}"
+        )
+    return problems
+
+
 def check_shape(rung: Rung, stage: Path) -> list[str]:
     """Check what the rendered repo's own gate cannot see: which files are and are not there."""
     packaged = rung.shape != "no-package"
@@ -304,7 +345,7 @@ def check_shape(rung: Rung, stage: Path) -> list[str]:
 def render(rung: Rung, parent: Path) -> None:
     """Render one rung and put the result through its own gate."""
     stage = build_scratch_repo(rung, parent)
-    run(
+    checklist = run(
         [sys.executable, str(stage / "scripts" / "init_repo.py"), *rung.answers],
         stage,
         label="init_repo.py",
@@ -322,6 +363,7 @@ def render(rung: Rung, parent: Path) -> None:
         + check_declined_cli(rung, stage)
         + check_template_artifacts(stage)
         + check_changelog(stage)
+        + check_next_steps(rung, checklist)
     )
     if problems:
         raise RenderError("\n".join(f"    {problem}" for problem in problems))

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -13,6 +13,13 @@ answers, then hand the result to its OWN gates — `pixi run check` and the docs
 assert what they cannot see. The rendered repo's own gate is the assertion, so almost nothing is
 asserted here.
 
+That gate runs over THIS repo's content, which is thin on purpose — research notes that quote
+nothing, a glossary of one term, a package of one function. So a green rung proves that
+`init-repo` subtracted correctly, and never that a gate behaves correctly on real material. No
+fixture corpus is coming: how a rule treats real material is a question for a test that writes
+the material it needs and removes it, the way `tests/test_quoted_evidence.py` does. See
+`docs/adr/0002-what-the-gate-does-not-check.md`.
+
 Two things about the scratch repo are deliberate:
 
 - It is **re-initialized, not cloned.** GitHub's template button creates a repo with one commit

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -40,6 +40,7 @@ import tempfile
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -272,16 +273,26 @@ def check_shape(rung: Rung, stage: Path) -> list[str]:
         "tests": packaged,
         "docs/api.md": packaged,
         # Never subtracted, at any rung. `check_changelog` asks the other half of that: the
-        # file ships, and the entries under its heading are this repo's or nobody's.
+        # file ships, and the entries under its heading are this repo's or nobody's. The
+        # licence is asked the same two questions — it ships, and the year below is this
+        # repo's rather than the template's.
         "CHANGELOG.md": True,
         "AGENTS.md": True,
         "CONTEXT.md": True,
+        "LICENSE": True,
     }
     problems = [
         f"{rel} is {'missing' if wanted else 'still here'}"
         for rel, wanted in expected.items()
         if (stage / rel).exists() != wanted
     ]
+    # The year `init-repo` ran, read from the clock and not from `scripts/init_repo.py`. It
+    # bites the year after the template's own file was written, which is exactly when a stamp
+    # that stopped running would start shipping a stale licence.
+    licence = stage / "LICENSE"
+    copyright_line = f"Copyright (c) {date.today().year} Liu Lab"
+    if licence.is_file() and copyright_line not in licence.read_text(encoding="utf-8"):
+        problems.append(f"LICENSE does not say {copyright_line!r}, the year this render ran")
     workflow = (stage / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     if "dogfood" in workflow:
         problems.append("ci.yml still carries the dogfood job")

--- a/scripts/dogfood.py
+++ b/scripts/dogfood.py
@@ -64,14 +64,15 @@ PLACEHOLDER = "new" + "pkg"
 #: them, each edited by a different anchor in `scripts/init_repo.py`.
 CLI_DEPENDENCY = "typer"
 
-#: What this repo says about ITSELF: its own records — how it chose its docs site, and the
-#: evidence behind the rules it ships — and the two files that publish it as the template, the
-#: page describing it and the config that names the site after it. Spelled out here rather than
-#: imported from `scripts/init_repo.py`, for the reason the two constants above are: an assertion
-#: that reads its expectation out of the thing it is checking cannot tell a deletion that ran
-#: from a list that quietly lost an entry.
+#: What this repo says about ITSELF: its own records — how it chose its docs site, what its gate
+#: deliberately does not check, and the evidence behind the rules it ships — and the two files
+#: that publish it as the template, the page describing it and the config that names the site
+#: after it. Spelled out here rather than imported from `scripts/init_repo.py`, for the reason
+#: the two constants above are: an assertion that reads its expectation out of the thing it is
+#: checking cannot tell a deletion that ran from a list that quietly lost an entry.
 TEMPLATE_ARTIFACTS = (
     "docs/adr/0001-docs-site-on-zensical.md",
+    "docs/adr/0002-what-the-gate-does-not-check.md",
     "docs/research/github-template-mechanics-2026-08-30.md",
     "docs/research/vale-setup-2026-08-30.md",
     "docs/research/zensical-viability-2026-08-30.md",

--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -24,9 +24,9 @@ Actions come in two kinds, and only one of them is dangerous:
 Exempt from that check, deleted unconditionally and tolerated when absent: the two skill
 directories, their four symlinks, the `dogfood` job and its task, `scripts/dogfood.py`, this
 file, the two files that publish this repo as the template — `docs/template/index.md` and the
-`mkdocs.template.yml` that names the site after it — and the template's own records, the ADR and
-the three research notes that say how the template was built. Their removal is the entire point,
-so nothing about them is negotiable.
+`mkdocs.template.yml` that names the site after it — and the template's own records, the two ADRs
+and the three research notes that say how the template was built and what its gate deliberately
+leaves alone. Their removal is the entire point, so nothing about them is negotiable.
 `CHANGELOG.md` is the one record handled the other way: the file always ships, and emptying it
 of the template's entries is guarded, so a late init never discards what someone wrote.
 
@@ -108,20 +108,26 @@ TEMPLATE_ONLY = (
     "scripts/init_repo.py",
 )
 
-#: The template's own records: the decision it made about its docs site, and the three notes
-#: behind the rules it ships. Same category as the two skills above — machinery whose removal is
-#: the point — so they go the same way, unconditionally and tolerated when absent.
+#: The template's own records: the two decisions it made about its own gate and docs site, and
+#: the three notes behind the rules it ships. Same category as the two skills above — machinery
+#: whose removal is the point — so they go the same way, unconditionally and tolerated when
+#: absent. A record whose subject is THIS repo is residue in a repo made from it, whatever it
+#: happens to number: `0002` reasons about `scripts/dogfood.py`, which the same render deletes.
 #:
 #: BY EXACT PATH, never by directory or glob. A repo initialized late may already have written
-#: `docs/adr/0002-*.md` or a research note of its own, and deleting `docs/adr/` would take it
+#: `docs/adr/0003-*.md` or a research note of its own, and deleting `docs/adr/` would take it
 #: with these. Both directories are allowed to disappear with their last file: `Repo.delete`
 #: prunes what it empties, and `docs/agents/domain.md` says `/domain-modeling` creates
 #: `docs/adr/` when it needs one and that a missing one is not an error. No `.gitkeep` — a
 #: tracked file whose only job is to exist is exactly the residue this script removes.
+#:
+#: Only `TEMPLATE_ADR` and `TEMPLATE_VALE_NOTE` are named, because only those two are cited
+#: again in `RECORD_POINTERS`. A record nothing else names stays a literal here.
 TEMPLATE_ADR = "docs/adr/0001-docs-site-on-zensical.md"
 TEMPLATE_VALE_NOTE = "docs/research/vale-setup-2026-08-30.md"
 TEMPLATE_RECORDS = (
     TEMPLATE_ADR,
+    "docs/adr/0002-what-the-gate-does-not-check.md",
     "docs/research/github-template-mechanics-2026-08-30.md",
     TEMPLATE_VALE_NOTE,
     "docs/research/zensical-viability-2026-08-30.md",

--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -55,6 +55,7 @@ import subprocess
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from datetime import date
 from pathlib import Path
 
 #: The template's placeholder identity, SPELLED IN TWO PIECES for the reason
@@ -152,6 +153,11 @@ TASKS_A_PACKAGE_NEEDS = frozenset({'test = "pytest"', 'build = "python -m build"
 CLI_DEPENDENCY = "typer"
 CLI_PROJECT_DEPENDENCY = f'dependencies = ["{CLI_DEPENDENCY}>=0.12"]'
 CLI_PIXI_DEPENDENCY = f'{CLI_DEPENDENCY} = ">=0.12"'
+
+#: The licence's copyright line. The pattern matches whatever year the template shipped, and the
+#: rendered repo gets the year this ran — a year written once is a fact that goes stale and
+#: nothing rechecks it. The text itself is the MIT licence every other lab repo carries.
+LICENSE_COPYRIGHT = r"(?m)^Copyright \(c\) \d{4} Liu Lab$"
 
 #: Committing needs an identity, and a fresh runner has none configured.
 GIT_IDENTITY = ("-c", "user.name=init-repo", "-c", "user.email=init-repo@localhost")
@@ -1028,6 +1034,15 @@ class Init:
             ),
         )
 
+    def stamp_license(self) -> None:
+        """Date the licence to the year this ran, rather than the year the template shipped."""
+        year = date.today().year
+        self.edit(
+            "LICENSE",
+            "the copyright year",
+            lambda text: _sub(text, LICENSE_COPYRIGHT, f"Copyright (c) {year} Liu Lab"),
+        )
+
     def write_readme(self) -> None:
         """Replace the template's README with this repo's own."""
         if not self.approved("README.md"):
@@ -1294,6 +1309,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     else:
         init.say("skipped", "the rename — nothing tracked names the placeholder any more")
     init.describe()
+    init.stamp_license()
     init.write_readme()
     init.reset_changelog()
 

--- a/scripts/init_repo.py
+++ b/scripts/init_repo.py
@@ -48,6 +48,7 @@ squashed, reads as fully modified, so it errs toward asking rather than deleting
 from __future__ import annotations
 
 import argparse
+import json
 import keyword
 import re
 import shutil
@@ -74,6 +75,21 @@ SHAPES = ("published", "not-published", "no-package")
 #: Used when a remote is a local path rather than a GitHub URL, which is what a scratch clone
 #: has. The lab account is the right guess and the site URL says so out loud.
 DEFAULT_OWNER = "liuhlab"
+
+#: The lab's label set, defined here and nowhere else — the wayfinder skill uses the
+#: `wayfinder:*` labels but declares no colour or description for any of them. GitHub copies no
+#: label when a repo is created from a template, so a new repo has the nine stock ones until
+#: someone clones these.
+LABEL_SOURCE = "liuhlab/liulab-repo-template"
+
+#: The `ci.yml` jobs each shape actually keeps. `no-package` deletes `test` and `build`, so a
+#: ruleset naming those would wait forever for a check that never reports, and every pull
+#: request in that repo would be unmergeable.
+SHAPE_CHECKS = {
+    "published": ("check", "test", "build", "docs"),
+    "not-published": ("check", "test", "build", "docs"),
+    "no-package": ("check", "docs"),
+}
 
 #: Deleted unconditionally, tolerated when absent, never checked against the first commit. This
 #: script is last, so everything else has already happened by the time it goes.
@@ -1167,8 +1183,57 @@ def readme(identity: Identity) -> str:
     return "\n".join(parts)
 
 
+def ruleset_body(checks: Sequence[str]) -> str:
+    """Build the ruleset a new repo's `main` gets: a pull request, and this shape's own checks.
+
+    Zero approvals, because a repo worked headlessly by agents has no second reviewer: what is
+    bought here is the pull request itself, which makes `pull_request` — the trigger that tests
+    the merge commit — the gate every change goes through.
+    """
+    return json.dumps(
+        {
+            "name": "main",
+            "target": "branch",
+            "enforcement": "active",
+            "conditions": {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+            "rules": [
+                {
+                    "type": "pull_request",
+                    "parameters": {
+                        "required_approving_review_count": 0,
+                        "dismiss_stale_reviews_on_push": False,
+                        "require_code_owner_review": False,
+                        "require_last_push_approval": False,
+                        "required_review_thread_resolution": False,
+                        # Stated rather than left out: GitHub defaults this one to true, which
+                        # adds a reviewer nobody asked for and blocks a headless merge.
+                        "require_extra_approval_for_unattributed_changes": False,
+                    },
+                },
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        # False, so a branch does not have to be rebased onto `main` to merge.
+                        "strict_required_status_checks_policy": False,
+                        "required_status_checks": [{"context": check} for check in checks],
+                    },
+                },
+            ],
+        },
+        separators=(",", ":"),
+    )
+
+
 def next_steps(identity: Identity, tag: str | None, *, pushed: bool) -> list[str]:
-    """List what is left for a person to do, including the parts that are not in this repo."""
+    """List what is left for a person to do, including the parts that are not in this repo.
+
+    The last two steps are GitHub state rather than tree state, so they are handed over as
+    COMMANDS with this repo's own owner and name already in them. This script prints them and
+    does not run them: it shells out to `git` alone and reaches the network only under `--push`,
+    and calling `gh` here would buy a pure-local script an external tool, an unauthenticated
+    failure path, and two more ways to half-succeed. The reader is the `init-repo` agent, still
+    running, which has `gh`.
+    """
     steps = ["Run `/init` to write `AGENTS.md` for this repo, then delete the sentinel line."]
     if not pushed:
         steps.append("Push the branch" + (f" and `{tag}`." if tag else "."))
@@ -1179,6 +1244,17 @@ def next_steps(identity: Identity, tag: str | None, *, pushed: bool) -> list[str
             "environment `pypi`. There is no API token in this repo, and there must never be one."
         )
         steps.append("Publish a GitHub Release to release. Pushing a tag does not publish.")
+    checks = SHAPE_CHECKS[identity.shape]
+    steps.append(
+        "Clone the lab's labels — a template copies none, so `--label ready-for-agent` fails "
+        "until you do:\n"
+        f"gh label clone {LABEL_SOURCE} --force --repo {identity.owner}/{identity.repo}"
+    )
+    steps.append(
+        f"Require a pull request and this repo's own checks ({', '.join(checks)}) on `main`:\n"
+        f"echo '{ruleset_body(checks)}' | "
+        f"gh api --method POST repos/{identity.owner}/{identity.repo}/rulesets --input -"
+    )
     steps.append("Turn on GitHub Pages for the `gh-pages` branch to publish the site.")
     return steps
 
@@ -1326,7 +1402,12 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     print("\n  next\n")
     for step in next_steps(identity, tag, pushed=args.push):
-        init.say("todo", step)
+        # A step may carry a command under it, on its own line, so the command is copy-pasteable
+        # rather than buried in a sentence. Leading spaces are nothing to a shell.
+        first, *command = step.split("\n")
+        init.say("todo", first)
+        for line in command:
+            init.note(line)
     return 0
 
 

--- a/src/newpkg/core.py
+++ b/src/newpkg/core.py
@@ -4,15 +4,8 @@
 def greet(name: str = "world") -> str:
     """Return a greeting addressed to `name`.
 
-    Parameters
-    ----------
-    name
-        Who to greet.
-
-    Returns
-    -------
-    str
-        The greeting.
+    The numpydoc section form is demonstrated once here, by `Examples`; a function this small
+    would not normally carry a section at all.
 
     Examples
     --------

--- a/styles/Lab/LengthDoc.yml
+++ b/styles/Lab/LengthDoc.yml
@@ -1,5 +1,6 @@
-# Word cap for agent-facing documents: AGENTS.md, CONTEXT.md, docs/agents/*,
-# skills/*/SKILL.md. The companion rule for ADRs is Lab.LengthAdr, at 400.
+# Word cap for agent-facing documents: AGENTS.md, docs/agents/*, skills/*/SKILL.md. The
+# companion rule for ADRs is Lab.LengthAdr, at 400. Not CONTEXT.md: a glossary only ever
+# grows, so conformance caps it per entry instead and no file cap applies.
 #
 # This is a dial, not a law. Raising it is a one-line diff here, made deliberately, with
 # the reason in the commit message. Do not raise it because a document ran long — that is

--- a/tests/test_quoted_evidence.py
+++ b/tests/test_quoted_evidence.py
@@ -1,0 +1,128 @@
+"""The two gates narrowed off `docs/research/`, with the gate's own tools as the oracle.
+
+`docs/research/` exists to quote upstream sources verbatim, and two gates used to refuse exactly
+that: `ruff format` rewrites Python code blocks inside Markdown, and `MD010` rejects the hard tab
+in a pasted TSV line. Both are now narrowed, and this file is what notices if either narrowing is
+deleted — this repo's own research notes carry no Python fence and no hard tab, so nothing else
+here can witness it.
+
+The second test is what keeps the exemption narrow: the same quotation under `tests/` is still
+reformatted. Without it, widening the exclusion to `*.md` would pass the first test too.
+
+Two mechanics the tests depend on, both measured against these tools:
+
+- **ruff is handed a DIRECTORY, never the file.** `force-exclude` is off by default, so a path
+  named on the command line is formatted even where the configuration excludes it. `fmt-check`
+  passes `.`, so a directory is what the gate does anyway.
+- **markdownlint runs from the repo root.** It does not look above its working directory for a
+  configuration, so the same file linted from `docs/research/` is checked by markdownlint's
+  defaults and not by this repo's.
+
+Both fixtures are written, read by the tools, and removed. Nothing is committed under
+`docs/research/`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+
+# What a research note is for: a Python fence nobody formatted, and a record whose tabs are the
+# data. Everything else here is only what stops markdownlint having a second opinion.
+QUOTED_EVIDENCE = (
+    "# Quoted evidence\n"
+    "\n"
+    "The upstream source, as it is written there:\n"
+    "\n"
+    "```python\n"
+    'd = {  "a":1 }\n'
+    "```\n"
+    "\n"
+    "And one line of its lookup table:\n"
+    "\n"
+    "```text\n"
+    "chr1\t100\t200\n"
+    "```\n"
+)
+
+
+@pytest.fixture
+def quotation() -> Iterator[Callable[[str], Path]]:
+    """Place the quotation in one directory of this repo, and take it away again.
+
+    It has to be this repo: both exclusions are anchored to the directory holding the
+    configuration, so a copy of the tree somewhere else matches neither. `docs/research/` is
+    created when absent, because `init-repo` prunes it with its last note.
+    """
+    written: list[Path] = []
+    created: list[Path] = []
+
+    def place(directory: str) -> Path:
+        parent = REPO / directory
+        if not parent.exists():
+            parent.mkdir(parents=True)
+            created.append(parent)
+        # The pid keeps two runs of this suite out of each other's way.
+        path = parent / f"quoted-evidence-{os.getpid()}.md"
+        path.write_text(QUOTED_EVIDENCE, encoding="utf-8")
+        written.append(path)
+        return path
+
+    yield place
+    for path in written:
+        path.unlink(missing_ok=True)
+    for parent in created:
+        parent.rmdir()
+
+
+def fmt_check(directory: str) -> subprocess.CompletedProcess[str]:
+    """The `fmt-check` task, scoped to one directory."""
+    return subprocess.run(
+        ["ruff", "format", "--check", directory],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def markdownlint() -> subprocess.CompletedProcess[str]:
+    """The `markdownlint` task, which its own configuration widens to every file in the repo."""
+    return subprocess.run(
+        ["markdownlint-cli2"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_a_research_note_may_quote_code_verbatim(quotation: Callable[[str], Path]) -> None:
+    """Both gates leave a note under `docs/research/` alone."""
+    path = quotation("docs/research")
+
+    formatter = fmt_check("docs/research")
+    assert formatter.returncode == 0, formatter.stdout
+
+    linter = markdownlint()
+    # The run covers every Markdown file in the repo, so its exit status is not this test's to
+    # claim. That it never names this file is.
+    assert path.name not in linter.stdout + linter.stderr
+
+
+def test_the_same_quotation_elsewhere_is_still_formatted(
+    quotation: Callable[[str], Path],
+) -> None:
+    """The exemption is `docs/research/` and not `*.md`."""
+    path = quotation("tests")
+
+    formatter = fmt_check("tests")
+
+    assert formatter.returncode == 1
+    assert path.name in formatter.stdout


### PR DESCRIPTION
What `liulab-protein` — the first repo made from this template — taught it, worked as the seven
tickets under #72. Eight commits, one per ticket plus two follow-ups for residue found on the way.

Net effect on a new repo: two gates stop firing on correct work, one word cap disappears, a
licence file appears, the closing checklist hands over two commands that make the repo's labels
and its branch protection real on day one, and `AGENTS.md` gains the chapter about this
template's own configuration that only a repo with real code could have written.

## What landed

| Ticket | Change |
| --- | --- |
| #79 | `[tool.ruff.format] exclude` and `MD010: code_blocks: false` narrowed off `docs/research/`, with `tests/test_quoted_evidence.py` proving both, and proving the same content elsewhere is still checked |
| #73 | `next_steps()` prints a `gh label clone` and a `gh api …/rulesets` command with the checks the rendered shape actually has; `AGENTS.md` states the pull-request rule; `dogfood` asserts the printed checklist |
| #74 | `CONTEXT.md` loses its file-level word cap — `[tool.liulab.agent-docs]`, `.vale.ini` and the cap table move together, and `Lab.LengthDoc`'s own comment stops claiming otherwise |
| #75 | `AGENTS.md` gains "Comments and docstrings are short" and the four gate traps; `src/newpkg/core.py` stops modelling 82% prose while keeping the doctest |
| #76 | `LICENSE` (MIT, byte-identical to the four sibling repos), stamped with the current year by `init_repo.py` and asserted by `dogfood` |
| #77 | A ruleset on this repo's own `main` — repository state, no tree change |
| #78 | ADR 0002 records the three declines, and is deleted on render like every other record here |

`Closes #72`. Sub-issues #73, #74, #75, #76, #77, #78 and #79 are closed with their own comments;
#70 and #71 are annotated with how they resolved.

## Two things found on the way, and fixed

- `styles/Lab/LengthDoc.yml`'s comment still said it capped `CONTEXT.md` — a fourth declaration
  of a convention the ticket moved in three places (`39dc5c9`).
- ADR 0002 was not in `TEMPLATE_RECORDS`, so every derived repo would have inherited a record
  numbered 0002 with no 0001 above it, reasoning about `dogfood` — a script the same render
  deletes (`5ff849f`).

## What this repo now requires of itself

Ruleset `main` (id `22290842`) is active on the default branch: a pull request, and the checks
`check`, `test`, `build`, `docs`. `dogfood` is not required and still runs on every pull request.
No bypass actors, admins included — which is what makes "a direct push to `main` is rejected"
true rather than true-for-everyone-but-the-owner. This pull request is the first thing to go
through it.

## Evidence

- `pixi run check` — 6 static steps, conformance 13/13, **110 tests** (was 108).
- `pixi run dogfood` — green on all three rungs: `published` 65s, `not-published` 61s,
  `no-package` 24s, each through its own `pixi install --locked`, `pixi run check` and
  `docs-build`.
- `pixi run docs-build --strict` — no issues.
- `AGENTS.md` measures **683 of its 1000** vale-words; ADR 0002 measures **368 of 400**. No cap
  was raised.

## Declined, and recorded rather than dropped

No conformance rule is added by any ticket here — two are narrowed and one word cap is removed.
The autouse test guards and the `plain_text()` helper from `liulab-protein` are not ported: two
fixtures nothing can opt out of is exactly the rule the Restraint section exists to stop. Issue
#70's suggestions 3 and 4 stay declined, with reasons in that issue's thread and in #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6yRLg8fbFuDs4zoQHSS1U
